### PR TITLE
feat: 시설 등록 기능 구현

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/facility/controller/FacilityController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/controller/FacilityController.java
@@ -1,0 +1,29 @@
+package com.metamong.mt.domain.facility.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
+import com.metamong.mt.domain.facility.service.FacilityService;
+import com.metamong.mt.global.apispec.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FacilityController {
+    private final FacilityService facilityService;
+    
+    @PostMapping("/facilities")
+    public ResponseEntity<BaseResponse<FacilityRegistrationResponseDto>> postFacility(
+            @RequestBody FacilityRegistrationRequestDto requestBody) {
+        return ResponseEntity.status(HttpStatus.CREATED.value())
+                .body(BaseResponse.of(this.facilityService.registerFacility(requestBody), HttpStatus.CREATED));
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityRegistrationRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityRegistrationRequestDto.java
@@ -1,0 +1,49 @@
+package com.metamong.mt.domain.facility.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.metamong.mt.domain.facility.model.Category;
+import com.metamong.mt.domain.facility.model.Facility;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FacilityRegistrationRequestDto {
+    private String fctName;
+    private String fctPostalCode;
+    private String fctAddress;
+    private String fctDetailAddress;
+    private Long catId;
+    private Long provId;
+    private String fctTel;
+    private String fctGuide;
+    private boolean openOnHolidays;
+    private LocalDateTime fctOpenTime;
+    private LocalDateTime fctCloseTime;
+    private int unitUsageTime;
+    private List<ImageRequestDto> images;
+    private List<ZoneRegistrationRequestDto> zones;
+    private List<String> addinfos;
+    
+    public Facility toEntity() {
+        return Facility.builder()
+                .cat(new Category(this.getCatId()))
+                .provId(this.getProvId())
+                .fctName(this.getFctName())
+                .fctPostalCode(this.getFctPostalCode())
+                .fctAddress(this.getFctAddress())
+                .fctDetailAddress(this.getFctDetailAddress())
+                .fctTel(this.getFctTel())
+                .fctGuide(this.getFctGuide())
+                .openOnHolidays(this.isOpenOnHolidays())
+                .fctOpenTime(this.getFctOpenTime())
+                .fctCloseTime(this.getFctCloseTime())
+                .unitUsageTime(this.getUnitUsageTime())
+                // TODO: fctLatitude, fctLongitude
+                .build();
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ImageRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ImageRequestDto.java
@@ -1,0 +1,14 @@
+package com.metamong.mt.domain.facility.dto.request;
+
+import com.metamong.mt.global.file.FileType;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ImageRequestDto {
+    private FileType fileType;
+    private int order;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ZoneRegistrationRequestDto {
+    private int zoneNo;
     private String zoneName;
     private int maxUserCount;
     private int isSharedZone;

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
@@ -1,0 +1,27 @@
+package com.metamong.mt.domain.facility.dto.request;
+
+import java.util.List;
+
+import com.metamong.mt.domain.facility.model.Zone;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ZoneRegistrationRequestDto {
+    private String zoneName;
+    private int maxUserCount;
+    private int isSharedZone;
+    private int hourlyRate;
+    private List<ImageRequestDto> images;
+    
+    public Zone toEntity() {
+        return Zone.builder()
+                .zoneName(this.zoneName)
+                .isSharedZone(this.isSharedZone)
+                .hourlyRate(this.hourlyRate)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
@@ -1,0 +1,16 @@
+package com.metamong.mt.domain.facility.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class FacilityRegistrationResponseDto {
+    private final Long generatedId;
+    private final List<ImageUploadUrlResponseDto> fctImageUploadUrls;
+    private final List<ImageUploadUrlResponseDto> zoneImageUploadUrls;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
@@ -1,6 +1,7 @@
 package com.metamong.mt.domain.facility.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,5 +13,5 @@ import lombok.ToString;
 public class FacilityRegistrationResponseDto {
     private final Long generatedId;
     private final List<ImageUploadUrlResponseDto> fctImageUploadUrls;
-    private final List<ImageUploadUrlResponseDto> zoneImageUploadUrls;
+    private final Map<Integer, List<ImageUploadUrlResponseDto>> zoneImageUploadUrlResponseDtosByZoneNo;
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/ImageUploadUrlResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/ImageUploadUrlResponseDto.java
@@ -1,0 +1,11 @@
+package com.metamong.mt.domain.facility.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ImageUploadUrlResponseDto {
+    private final int order;
+    private final String uploadUrl;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/AdditionalInfo.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/AdditionalInfo.java
@@ -1,0 +1,35 @@
+package com.metamong.mt.domain.facility.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "additional_info")
+@SequenceGenerator(
+        name = "addinfo_pk_generator",
+        sequenceName = "addinfo_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class AdditionalInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "addinfo_pk_generator")
+    private Long addinfoId;
+    
+    private Long fctId;
+    private String addinfoDesc;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Category.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Category.java
@@ -1,0 +1,61 @@
+package com.metamong.mt.domain.facility.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@SequenceGenerator(
+        name = "cat_pk_generator",
+        sequenceName = "cat_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cat_pk_generator")
+    private Long catId;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_cat_id")
+    private Category parentCat;
+    
+    private String catName;
+    
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "parentCat")
+    private List<Category> children = new ArrayList<>();
+    
+    public Category(Long catId) {
+        this.catId = catId;
+    }
+    
+    public Category(String catName) {
+        this.catName = catName;
+    }
+    
+    public Category(Category parentCat, String catName) {
+        this.parentCat = parentCat;
+        this.catName = catName;
+    }
+    
+    public void addChildCategory(Category childCategory) {
+        this.children.add(childCategory);
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
@@ -1,0 +1,65 @@
+package com.metamong.mt.domain.facility.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "facility")
+@SequenceGenerator(
+        name = "fct_pk_generator",
+        sequenceName = "fct_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Facility {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "fct_pk_generator")
+    private Long fctId;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cat_id")
+    private Category cat;
+    
+    private Long provId;
+    private String fctName;
+    private String fctPostalCode;
+    private String fctAddress;
+    private String fctDetailAddress;
+    private String fctTel;
+    private String fctGuide;
+    private boolean isOpenOnHolidays;
+    private LocalDateTime fctOpenTime;
+    private LocalDateTime fctCloseTime;
+    private int unitUsageTime;
+    
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+    
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+    
+    @Builder.Default
+    private FacilityState fctState = FacilityState.REG_REQUESTED;
+    
+    private double fctLatitude;
+    private double fctLongitude;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
@@ -1,7 +1,13 @@
 package com.metamong.mt.domain.facility.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.metamong.mt.global.image.model.FacilityImage;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -46,7 +53,10 @@ public class Facility {
     private String fctDetailAddress;
     private String fctTel;
     private String fctGuide;
-    private boolean isOpenOnHolidays;
+    
+    @Column(name = "is_open_on_holidays")
+    private boolean openOnHolidays;
+    
     private LocalDateTime fctOpenTime;
     private LocalDateTime fctCloseTime;
     private int unitUsageTime;
@@ -62,4 +72,12 @@ public class Facility {
     
     private double fctLatitude;
     private double fctLongitude;
+    
+    @OneToMany(mappedBy = "fct", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @Builder.Default
+    private List<FacilityImage> fctImages = new ArrayList<>();
+    
+    public void addFctImage(FacilityImage fctImage) {
+        this.fctImages.add(fctImage);
+    }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/FacilityState.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/FacilityState.java
@@ -1,0 +1,7 @@
+package com.metamong.mt.domain.facility.model;
+
+public enum FacilityState {
+    REG_REQUESTED,
+    REGISTERED,
+    DELETED
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
@@ -35,7 +35,7 @@ public class Zone {
     private Long fctId;
     private String zoneName;
     private Integer maxUserCount;
-    private Boolean isSharedZone;
+    private Integer isSharedZone;
     private Integer hourlyRate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
@@ -1,11 +1,17 @@
 package com.metamong.mt.domain.facility.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.metamong.mt.global.image.model.ZoneImage;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -39,4 +45,12 @@ public class Zone {
     private Integer hourlyRate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    
+    @Builder.Default
+    @OneToMany(mappedBy = "zone", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<ZoneImage> images = new ArrayList<>();
+    
+    public void addZoneImage(ZoneImage zoneImage) {
+        this.images.add(zoneImage);
+    }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
@@ -1,0 +1,42 @@
+package com.metamong.mt.domain.facility.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "zone")
+@SequenceGenerator(
+        name = "zone_pk_generator",
+        sequenceName = "zone_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Zone {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "zone_pk_generator")
+    private Long zoneId;
+    
+    private Long fctId;
+    private String zoneName;
+    private Integer maxUserCount;
+    private Boolean isSharedZone;
+    private Integer hourlyRate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/FacilityRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/FacilityRepository.java
@@ -1,0 +1,8 @@
+package com.metamong.mt.domain.facility.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.metamong.mt.domain.facility.model.Facility;
+
+public interface FacilityRepository extends JpaRepository<Facility, Long> {
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/ZoneRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/ZoneRepository.java
@@ -1,0 +1,8 @@
+package com.metamong.mt.domain.facility.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.metamong.mt.domain.facility.model.Zone;
+
+public interface ZoneRepository extends JpaRepository<Zone, Long> {
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
@@ -5,13 +5,10 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import com.metamong.mt.domain.facility.model.AdditionalInfo;
-import com.metamong.mt.domain.facility.model.Zone;
 
 @Repository
 @Mapper
 public interface FacilityMapper {
-
-    void saveZone(@Param("zone") Zone zone);
     
     void saveAdditionalInfo(@Param("addinfo") AdditionalInfo addinfo);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
@@ -1,0 +1,17 @@
+package com.metamong.mt.domain.facility.repository.mybatis;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
+
+import com.metamong.mt.domain.facility.model.AdditionalInfo;
+import com.metamong.mt.domain.facility.model.Zone;
+
+@Repository
+@Mapper
+public interface FacilityMapper {
+
+    void saveZone(@Param("zone") Zone zone);
+    
+    void saveAdditionalInfo(@Param("addinfo") AdditionalInfo addinfo);
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
@@ -1,0 +1,66 @@
+package com.metamong.mt.domain.facility.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.request.ImageRequestDto;
+import com.metamong.mt.domain.facility.dto.request.ZoneRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
+import com.metamong.mt.domain.facility.dto.response.ImageUploadUrlResponseDto;
+import com.metamong.mt.domain.facility.model.AdditionalInfo;
+import com.metamong.mt.domain.facility.model.Facility;
+import com.metamong.mt.domain.facility.repository.jpa.FacilityRepository;
+import com.metamong.mt.domain.facility.repository.mybatis.FacilityMapper;
+import com.metamong.mt.global.file.FilenameResolver;
+import com.metamong.mt.global.image.model.FacilityImage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DefaultFacilityService implements FacilityService {
+    private final FacilityRepository facilityRepository;
+    private final FacilityMapper facilityMapper;
+    private final FilenameResolver filenameResolver;
+    
+    @Override
+    public FacilityRegistrationResponseDto registerFacility(FacilityRegistrationRequestDto dto) {
+        Facility newFacility = dto.toEntity();
+        this.facilityRepository.save(newFacility);
+        
+        Map<Integer, String> faciltiyFilePathByOrder = new HashMap<>();
+        for (ImageRequestDto imageRequestDto : dto.getImages()) {
+            faciltiyFilePathByOrder.put(imageRequestDto.getOrder(),
+                    this.filenameResolver.generateUuidFilename(imageRequestDto.getFileType()));
+        }
+        
+        for (Map.Entry<Integer, String> entry : faciltiyFilePathByOrder.entrySet()) {
+            newFacility.addFctImage(new FacilityImage(entry.getValue(), entry.getKey(), newFacility));
+        }
+        
+        dto.getZones().stream()
+                .map(ZoneRegistrationRequestDto::toEntity)
+                .forEach((zone) -> this.facilityMapper.saveZone(zone));
+        
+        dto.getAddinfos().stream()
+                .map((desc) -> AdditionalInfo.builder()
+                        .fctId(newFacility.getFctId())
+                        .addinfoDesc(desc)
+                        .build())
+                .forEach((addinfo) -> this.facilityMapper.saveAdditionalInfo(addinfo));
+        
+        return new FacilityRegistrationResponseDto(
+                newFacility.getFctId(),
+                newFacility.getFctImages().stream()
+                        .map((image) -> new ImageUploadUrlResponseDto(image.getImgDisplayOrder(), image.getImgPath()))
+                        .toList(),
+                List.of() // TODO: zone image upload url list
+        );
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/FacilityService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/FacilityService.java
@@ -1,0 +1,9 @@
+package com.metamong.mt.domain.facility.service;
+
+import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
+
+public interface FacilityService {
+
+    FacilityRegistrationResponseDto registerFacility(FacilityRegistrationRequestDto dto);
+}

--- a/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FacilityImage extends Image {
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fct_id")
     private Facility fct;

--- a/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
@@ -1,0 +1,20 @@
+package com.metamong.mt.global.image.model;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("F")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FacilityImage extends Image {
+    private Long fctId;
+    
+    public FacilityImage(String imgPath, Integer imgDisplayOrder, Long fctId) {
+        super(imgPath, imgDisplayOrder);
+        this.fctId = fctId;
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
@@ -1,7 +1,12 @@
 package com.metamong.mt.global.image.model;
 
+import com.metamong.mt.domain.facility.model.Facility;
+
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,10 +16,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FacilityImage extends Image {
-    private Long fctId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fct_id")
+    private Facility fct;
     
-    public FacilityImage(String imgPath, Integer imgDisplayOrder, Long fctId) {
+    public FacilityImage(String imgPath, Integer imgDisplayOrder, Facility fct) {
         super(imgPath, imgDisplayOrder);
-        this.fctId = fctId;
+        this.fct = fct;
     }
 }

--- a/backend/src/main/java/com/metamong/mt/global/image/model/Image.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/Image.java
@@ -1,0 +1,49 @@
+package com.metamong.mt.global.image.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "image")
+@SequenceGenerator(
+        name = "img_pk_generator",
+        sequenceName = "img_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "img_attatched_to")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "img_pk_generator")
+    private Long imgId;
+    
+    private String imgPath;
+    private Integer imgDisplayOrder;
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
+    
+    public Image(Long imgId) {
+        this.imgId = imgId;
+    }
+    
+    protected Image(String imgPath, Integer imgDisplayOrder) {
+        this.imgPath = imgPath;
+        this.imgDisplayOrder = imgDisplayOrder;
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/global/image/model/ZoneImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/ZoneImage.java
@@ -1,0 +1,28 @@
+package com.metamong.mt.global.image.model;
+
+import com.metamong.mt.domain.facility.model.Zone;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Z")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ZoneImage extends Image {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+    
+    public ZoneImage(String imgPath, Integer imgDisplayOrder, Zone zone) {
+        super(imgPath, imgDisplayOrder);
+        this.zone = zone;
+    }
+}

--- a/backend/src/main/resources/mapper/facility/FacilityMapper.xml
+++ b/backend/src/main/resources/mapper/facility/FacilityMapper.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+    
+<mapper namespace="com.metamong.mt.domain.facility.repository.mybatis.FacilityMapper">
+
+    <insert id="saveZone" parameterType="com.metamong.mt.domain.facility.model.Zone">
+        <![CDATA[
+            INSERT INTO zone (
+                zone_id,
+                fct_id,
+                zone_name,
+                max_user_count,
+                is_shared_zone,
+                hourly_rate
+            ) VALUES (
+                zone_pk_seq.NEXTVAL,
+                #{zone.fctId: NUMBER},
+                #{zone.zoneName: VARCHAR},
+                #{zone.maxUserCount: NUMBER},
+                #{zone.sharedZone: NUMBER},
+                #{zone.hourlyRate: NUMBER}
+            )
+        ]]>
+    </insert>
+    
+    <insert id="saveAdditionalInfo" parameterType="com.metamong.mt.domain.facility.model.AdditionalInfo">
+        <![CDATA[
+            INSERT INTO additional_info (
+                addinfo_id,
+                fct_id,
+                addinfo_desc
+            ) VALUES (
+                addinfo_pk_seq.NEXTVAL,
+                #{addinfo.fctId},
+                #{addinfo.addinfoDesc}
+            )
+        ]]>
+    </insert>
+    
+    <insert id="saveCategory" parameterType="com.metamong.mt.domain.facility.model.Category">
+        <![CDATA[
+            INSERT INTO category (
+                cat_id,
+                parent_cat_id,
+                cat_name
+            ) VALUES (
+                cat_pk_seq.NEXTVAL,
+                <if test="cat.parentCat == null">
+                    NULL,
+                </if>
+                <if test="cat.parentCat != null">
+                    #{cat.parentCat.catId: NUMBER},
+                </if>
+                #{cat.catName}
+            )
+        ]]>
+    </insert>
+</mapper>

--- a/backend/src/main/resources/mapper/facility/FacilityMapper.xml
+++ b/backend/src/main/resources/mapper/facility/FacilityMapper.xml
@@ -3,26 +3,6 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
     
 <mapper namespace="com.metamong.mt.domain.facility.repository.mybatis.FacilityMapper">
-
-    <insert id="saveZone" parameterType="com.metamong.mt.domain.facility.model.Zone">
-        <![CDATA[
-            INSERT INTO zone (
-                zone_id,
-                fct_id,
-                zone_name,
-                max_user_count,
-                is_shared_zone,
-                hourly_rate
-            ) VALUES (
-                zone_pk_seq.NEXTVAL,
-                #{zone.fctId: NUMBER},
-                #{zone.zoneName: VARCHAR},
-                #{zone.maxUserCount: NUMBER},
-                #{zone.sharedZone: NUMBER},
-                #{zone.hourlyRate: NUMBER}
-            )
-        ]]>
-    </insert>
     
     <insert id="saveAdditionalInfo" parameterType="com.metamong.mt.domain.facility.model.AdditionalInfo">
         <![CDATA[


### PR DESCRIPTION
# 설명
시설 등록 기능 구현.  Repository 개수를 줄이기 위해 JPA와 MyBatis를 섞어서 썼으며, 시설 엔티티 저장에는 JPA를 썼고, zone과 additional info 저장에는 MyBatis를 사용했다.
또한 이미지 등록을 위해 Image 엔티티를 사용했는데, 이미지 엔티티에 대한 객체지향적 접근을 위해 Inheritance 전략을 사용했다.

# 변경사항
- 시설 등록 기능 구현
- 이미지 엔티티 정의
