### PR TITLE
enhance: Zone 이미지 업로드 구현

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneRegistrationRequestDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ZoneRegistrationRequestDto {
+    private int zoneNo;
     private String zoneName;
     private int maxUserCount;
     private int isSharedZone;

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityRegistrationResponseDto.java
@@ -1,6 +1,7 @@
 package com.metamong.mt.domain.facility.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,5 +13,5 @@ import lombok.ToString;
 public class FacilityRegistrationResponseDto {
     private final Long generatedId;
     private final List<ImageUploadUrlResponseDto> fctImageUploadUrls;
-    private final List<ImageUploadUrlResponseDto> zoneImageUploadUrls;
+    private final Map<Integer, List<ImageUploadUrlResponseDto>> zoneImageUploadUrlResponseDtosByZoneNo;
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Zone.java
@@ -1,11 +1,17 @@
 package com.metamong.mt.domain.facility.model;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.metamong.mt.global.image.model.ZoneImage;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -39,4 +45,12 @@ public class Zone {
     private Integer hourlyRate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    
+    @Builder.Default
+    @OneToMany(mappedBy = "zone", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<ZoneImage> images = new ArrayList<>();
+    
+    public void addZoneImage(ZoneImage zoneImage) {
+        this.images.add(zoneImage);
+    }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/ZoneRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/jpa/ZoneRepository.java
@@ -1,0 +1,8 @@
+package com.metamong.mt.domain.facility.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.metamong.mt.domain.facility.model.Zone;
+
+public interface ZoneRepository extends JpaRepository<Zone, Long> {
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapper.java
@@ -5,13 +5,10 @@ import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import com.metamong.mt.domain.facility.model.AdditionalInfo;
-import com.metamong.mt.domain.facility.model.Zone;
 
 @Repository
 @Mapper
 public interface FacilityMapper {
-
-    void saveZone(@Param("zone") Zone zone);
     
     void saveAdditionalInfo(@Param("addinfo") AdditionalInfo addinfo);
 }

--- a/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/FacilityImage.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FacilityImage extends Image {
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fct_id")
     private Facility fct;

--- a/backend/src/main/java/com/metamong/mt/global/image/model/ZoneImage.java
+++ b/backend/src/main/java/com/metamong/mt/global/image/model/ZoneImage.java
@@ -1,0 +1,28 @@
+package com.metamong.mt.global.image.model;
+
+import com.metamong.mt.domain.facility.model.Zone;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Z")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ZoneImage extends Image {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "zone_id")
+    private Zone zone;
+    
+    public ZoneImage(String imgPath, Integer imgDisplayOrder, Zone zone) {
+        super(imgPath, imgDisplayOrder);
+        this.zone = zone;
+    }
+}

--- a/backend/src/main/resources/mapper/facility/FacilityMapper.xml
+++ b/backend/src/main/resources/mapper/facility/FacilityMapper.xml
@@ -3,26 +3,6 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
     
 <mapper namespace="com.metamong.mt.domain.facility.repository.mybatis.FacilityMapper">
-
-    <insert id="saveZone" parameterType="com.metamong.mt.domain.facility.model.Zone">
-        <![CDATA[
-            INSERT INTO zone (
-                zone_id,
-                fct_id,
-                zone_name,
-                max_user_count,
-                is_shared_zone,
-                hourly_rate
-            ) VALUES (
-                zone_pk_seq.NEXTVAL,
-                #{zone.fctId: NUMBER},
-                #{zone.zoneName: VARCHAR},
-                #{zone.maxUserCount: NUMBER},
-                #{zone.sharedZone: NUMBER},
-                #{zone.hourlyRate: NUMBER}
-            )
-        ]]>
-    </insert>
     
     <insert id="saveAdditionalInfo" parameterType="com.metamong.mt.domain.facility.model.AdditionalInfo">
         <![CDATA[


### PR DESCRIPTION
# 설명
이전 PR에 없었던 Zone 이미지 업로드 구현.
시설 등록할 때 시설 등록 요청과 파일 업로드 요청은 따로 이루어진다. 이는 백엔드 서버에 대한 IO 요청을 줄이기 위해서는 프론트에서 S3로 직접 업로드해야 하기 때문이다. 이를 위해 클라이언트에서는 시설 등록 후 이미지 파일을 업로드할 URL (presigned URL)을 응답받아야 하는데, 어떤 이미지를 어떤 URL로 업로드해야 할지를 프론트엔드에서 식별해야 한다. 업로드할 각 존의 이미지를 식별하기 위해 클라이언트에서 ```zoneNo```를 넘겨줌으로써 각 ```zoneNo```에 이미지 업로드 URL이 매핑되도록 하였다.

# 변경사항
- ZoneImage 엔티티 정의
- 시설 등록 시 zone 이미지 등록되도록 구현

# 참고자료
[Presigned URL을 이용하여 S3로 파일 업로드](https://velog.io/@mimi0905/Presigned-URL%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-S3%EB%A1%9C-%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C)
