### PR TITLE
refactor: 스프링 시큐리티 약간 변경

### DIFF
--- a/backend/src/main/java/com/metamong/mt/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/metamong/mt/global/auth/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import com.metamong.mt.global.config.constant.HttpRequestAuthorizationDefinition;
@@ -22,7 +21,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
 

--- a/backend/src/main/java/com/metamong/mt/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/metamong/mt/global/config/SecurityConfig.java
@@ -54,6 +54,10 @@ public class SecurityConfig {
 	    http.authorizeHttpRequests((registry) -> {
             HttpRequestAuthorizationDefinition.defineRequestMatcher(registry);
         });
+
+        // Spring Security JWT 필터 로드
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtAuthenticationManager, jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class);
 	    
 	    return http.build();
 	}


### PR DESCRIPTION
# 설명
JwtAuthenticationFilter가 스프링 빈으로 등록되니까 WebMvcTest에서 의존 주입 문제 발생.
JwtAuthenticationFilter 스프링 빈으로 등록되는 걸 막고 SecurityConfig에서 직접 생성

# 변경사항
- JwtAuthenticationFilter 스프링 빈으로 등록 X
