### PR TITLE
feat: 회원 조회 관련 개발

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/member/dto/request/ProviderSignUpRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/dto/request/ProviderSignUpRequestDto.java
@@ -3,6 +3,7 @@ package com.metamong.mt.domain.member.dto.request;
 import java.time.LocalDate;
 
 import com.metamong.mt.domain.member.dto.request.validation.EnumValidator;
+import com.metamong.mt.domain.member.model.FctProvider;
 import com.metamong.mt.domain.member.model.Member;
 import com.metamong.mt.domain.member.model.constant.Gender;
 import com.metamong.mt.domain.member.model.constant.Role;
@@ -50,10 +51,19 @@ public class ProviderSignUpRequestDto {
     @NotEmpty(message = "상세 주소는 필수입니다.")
     private String memDetailAddress;
     
+    @NotEmpty(message = "사업자명은 필수입니다.")
     private String bizName;
+    
+    @NotEmpty(message = "사업자등록번호는 필수입니다.")
     private String bizRegNum;
+    
+    @NotEmpty(message = "은행코드는 필수입니다.")
     private String bankCode;
+    
+    @NotEmpty(message = "계좌번호는 필수입니다.")
     private String provAccount;
+    
+    @NotEmpty(message = "예금주명은 필수입니다.")
     private String provAccountOwner;
     
     public Gender getGender() {
@@ -71,7 +81,17 @@ public class ProviderSignUpRequestDto {
 			 .memPostalCode(this.memPostalCode)
 			 .memAddress(this.memAddress)
 			 .memDetailAddress(this.memDetailAddress)
-		    .role(Role.ROLE_PROV)
-		    .build();
+             .role(Role.ROLE_PROV)
+             .build();
+    }
+    
+    public FctProvider toProvider() {
+        return FctProvider.builder()
+                .bizName(this.bizName)
+                .bizRegNum(this.bizRegNum)
+                .bankCode(this.bankCode)
+                .provAccount(this.provAccount)
+                .provAccountOwner(this.provAccountOwner)
+                .build();
     }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/member/dto/response/MemberResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/dto/response/MemberResponseDto.java
@@ -8,9 +8,11 @@ import com.metamong.mt.domain.member.model.constant.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class MemberResponseDto {
@@ -19,16 +21,16 @@ public class MemberResponseDto {
 	private final String memName;
 	private final String memPhone;
 	private final Gender gender;
-	
 	private final LocalDate birthDate;
 	private final String memPostalCode;
 	private final String memAddress;
 	private final String memDetailAddress;
-    private final String bizName;
+	private final Role role;
+
+	private final String bizName;
     private final String bizRegNum;
     private final String bankCode;
     private final String provAccount;
     private final String provAccountOwner;
-    private final Role role;
     
 }

--- a/backend/src/main/java/com/metamong/mt/domain/member/model/FctProvider.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/model/FctProvider.java
@@ -1,0 +1,49 @@
+package com.metamong.mt.domain.member.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Table(name = "fct_provider")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class FctProvider {
+    
+    @Id
+    private Long provId;
+    
+    @OneToOne
+    @MapsId
+    @JoinColumn(name="mem_id")
+    private Member member;
+    
+    @Column(name="bank_code")
+    private String bankCode;
+    
+    @Column(name="biz_name")
+    private String bizName;
+    
+    @Column(name="biz_reg_num")
+    private String bizRegNum;
+    
+    @Column(name="prov_account")
+    private String provAccount;
+    
+    @Column(name="prov_account_owner")
+    private String provAccountOwner;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/member/model/Member.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/model/Member.java
@@ -3,55 +3,104 @@ package com.metamong.mt.domain.member.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+
 import com.metamong.mt.domain.member.dto.request.UpdateRequestDto;
 import com.metamong.mt.domain.member.model.constant.Gender;
 import com.metamong.mt.domain.member.model.constant.Role;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Entity
-@Getter @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="member")
+@SequenceGenerator(
+        name = "mem_pk_generator",
+        sequenceName = "mem_pk_seq",
+        initialValue = 1,
+        allocationSize = 1
+)
+@Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class Member {
     
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="mem_pk_generator")
+    @Column(name="mem_id")
     private Long memId;
     
+    @Column(name="email", nullable=false, unique=true)
     private String email;
+    
+    @Column(name="mem_name", nullable=false)
     private String memName;
+    
+    @Column(name="password")
     private String password;
+    
+    @Column(name="mem_phone")
     private String memPhone;
     
     @Enumerated(EnumType.STRING)
+    @Column(name="gender", length=1)
     private Gender gender;
     
+    @Column(name="birth_date")
     private LocalDate birthDate;
+    
+    @Column(name="mem_postal_code")
     private String memPostalCode;
+    
+    @Column(name="mem_detail_address")
     private String memDetailAddress;
+    
+    @Column(name="mem_address")
     private String memAddress;
     
     @Enumerated(EnumType.STRING)
+    @Column(name="role")
     private Role role;
     
+    @Column(name="refresh_token")
     private String refreshToken;
+    
+    @CreationTimestamp
+    @Column(name="created_at")
+    @ColumnDefault(value="SYSDATE")
     private LocalDateTime createdAt = null;
+    
+    @Column(name="updated_at")
     private LocalDateTime updatedAt = null;
+    
+    @Column(name="mem_banned_until")
     private LocalDateTime memBannedUntil = null;
-    private Character isDeleted = 'N';
+    
+    @Column(name="is_del", length=1)
+    @ColumnDefault(value="'N'")
+    private Character isDel = 'N';
+    
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private FctProvider fctProvider;
     
     public void updateInfo(UpdateRequestDto dto) {
         this.memName = dto.getMemName();

--- a/backend/src/main/java/com/metamong/mt/domain/member/repository/jpa/FctProviderRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/repository/jpa/FctProviderRepository.java
@@ -1,0 +1,11 @@
+package com.metamong.mt.domain.member.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.metamong.mt.domain.member.model.FctProvider;
+
+@Repository
+public interface FctProviderRepository extends JpaRepository<FctProvider, Long>{
+
+}

--- a/backend/src/main/java/com/metamong/mt/domain/payment/model/Payment.java
+++ b/backend/src/main/java/com/metamong/mt/domain/payment/model/Payment.java
@@ -1,0 +1,58 @@
+package com.metamong.mt.domain.payment.model;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import com.metamong.mt.domain.reservation.model.Reservation;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="payment")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+public class Payment {
+    
+    @Id
+    private Long rvtId;
+    
+    @OneToOne
+    @MapsId
+    @JoinColumn(name="rvt_id")
+    private Reservation reservation;
+    
+    @Column(name="pay_price")
+    private Long payPrice;
+    
+    @Column(name="pay_state")
+    private Character payState;
+    
+    @Column(name="pay_method")
+    private String payMethod;
+    
+    @Column(name="pay_date")
+    @ColumnDefault(value="SYSDATE")
+    private LocalDateTime payDate;
+    
+    @Column(name="cancel_date")
+    private LocalDateTime cancel_date;
+    
+    @Column(name="refund_bank_code")
+    private String refundBankCode;
+    
+    @Column(name="refundAccountOwner")
+    private String refundAccountOwner;
+
+}

--- a/backend/src/main/java/com/metamong/mt/domain/payment/repository/jpa/PaymentRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/payment/repository/jpa/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.metamong.mt.domain.payment.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.metamong.mt.domain.payment.model.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long>{
+
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,14 +16,14 @@ const routes = [
 	{ path: '/mypage', component: MyPage },
 	{ path: '/update', component: UpdateMember },
 	{ path: '/signup', component: SignUp},
-	{ path: '/download', component: Download  },
-	
 	//{ path: '/socket', component: Socket  },
-	//{ path: '/admin', component: Admin },
-	//{ path: '/admin/socket', component: ChatAdmin },
-	//{ path: '/admin/chatlist', component: ChatList },
+	{ path: '/download', component: Download  },
 
-	{ path: '/reservation', component: Reservation},
+	{ path: '/admin', component: Admin },
+	{ path: '/admin/chatlist', component: ChatList },
+
+	{ path: '/reservation', component: Reservation },
+	{ path: '/reservation/:id', component: DetailReservation, props: true },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
# 설명
시설 이용자와 시설 제공자의 데이터 분리를 위해 entity를 두개 로 따로 두었습니다.

# 변경사항
- 시설 이용자와 시설 제공자 공통 모델 : Member
- 시설 제공자만 가지고 있는 데이터 : FctProvider
- 둘은 1:1 관계로, 서로의 객체를 필드로 가지고 있습니다.
- 회원 정보 저장 시 같이 저장됩니다.
- 시설 이용자 데이터를 불러올 땐 시설 이용자와 시설 제공자 공통 데이터만 불러옵니다.
![image](https://github.com/user-attachments/assets/ff73010c-1f10-4fdd-908c-ad4787733d89)
- 시설 제공자 데이터를 불러올 땐 공통 데이터와 시설 제공자만 가지고 있는 데이터를 같이 불러옵니다.
![image](https://github.com/user-attachments/assets/eb3863f2-ab74-4b1e-8007-2ded91689eab)
