### PR TITLE
feat: 시설 수정 DTO 정의 및 API 엔드포인트 구현

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/facility/controller/FacilityController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/controller/FacilityController.java
@@ -5,13 +5,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.request.FacilityUpdateRequestDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityResponseDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityUpdateResponseDto;
 import com.metamong.mt.domain.facility.service.FacilityService;
 import com.metamong.mt.global.apispec.BaseResponse;
 
@@ -36,6 +39,20 @@ public class FacilityController {
     @GetMapping("/facilities/{facilityId}")
     public ResponseEntity<BaseResponse<FacilityResponseDto>> getFacility(@PathVariable("facilityId") Long facilityId) {
         FacilityResponseDto result = this.facilityService.getFacility(facilityId);
+        if (log.isDebugEnabled()) {
+            log.debug("result={}", result);
+        }
+        return ResponseEntity.ok(
+                BaseResponse.of(result, HttpStatus.OK)
+        );
+    }
+    
+    @PutMapping("/facilities/{facilityId}")
+    public ResponseEntity<BaseResponse<FacilityUpdateResponseDto>> putFacility(
+            @PathVariable("facilityId") Long facilityId,
+            @RequestBody FacilityUpdateRequestDto requestBody
+    ) {
+        FacilityUpdateResponseDto result = this.facilityService.updateFacility(facilityId, requestBody);
         if (log.isDebugEnabled()) {
             log.debug("result={}", result);
         }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityUpdateRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityUpdateRequestDto.java
@@ -1,5 +1,10 @@
 package com.metamong.mt.domain.facility.dto.request;
 
+import java.time.LocalDateTime;
+
+import com.metamong.mt.global.apispec.CommonListUpdateRequestDto;
+import com.metamong.mt.global.constant.BooleanAlt;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +14,19 @@ import lombok.ToString;
 @Getter
 @ToString
 public class FacilityUpdateRequestDto {
-    
-    
-    private String facilityName;
+    private String fctName;
+    private String fctPostalCode;
+    private String fctAddress;
+    private String fctDetailAddress;
+    private String fctTel;
+    private String catId;
+    private String fctGuide;
+    private BooleanAlt isOpenOnHolidays;
+    private LocalDateTime fctOpenTime;
+    private LocalDateTime fctCloseTime;
+    private Integer unitUsageTime;
+    private Double fctLatitude;
+    private Double fctLongitude;
+    private CommonListUpdateRequestDto<ZoneUpdateRequestDto, Long> zones;
+    private CommonListUpdateRequestDto<String, Long> addinfos;
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneUpdateRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/ZoneUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.metamong.mt.domain.facility.dto.request;
+
+import com.metamong.mt.global.constant.BooleanAlt;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class ZoneUpdateRequestDto {
+    private String zoneName;
+    private int maxUserCount;
+    private BooleanAlt isSharedZone;
+    private int hourlyRate;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityUpdateResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityUpdateResponseDto.java
@@ -1,0 +1,15 @@
+package com.metamong.mt.domain.facility.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class FacilityUpdateResponseDto {
+    private final List<Long> generatedZoneIds;
+    private final List<Long> generatedAdditionalInfoIds;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
@@ -5,10 +5,12 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.request.FacilityUpdateRequestDto;
 import com.metamong.mt.domain.facility.dto.request.ImageRequestDto;
 import com.metamong.mt.domain.facility.dto.request.ZoneRegistrationRequestDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityResponseDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityUpdateResponseDto;
 import com.metamong.mt.domain.facility.dto.response.ImageUploadUrlResponseDto;
 import com.metamong.mt.domain.facility.dto.response.ZoneImageUploadUrlResponseDto;
 import com.metamong.mt.domain.facility.model.AdditionalInfo;
@@ -83,5 +85,10 @@ public class DefaultFacilityService implements FacilityService {
     @Override
     public FacilityResponseDto getFacility(Long facilityId) {
         return this.facilityMapper.findFacilityById(facilityId);
+    }
+
+    @Override
+    public FacilityUpdateResponseDto updateFacility(Long fctId, FacilityUpdateRequestDto dto) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/FacilityService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/FacilityService.java
@@ -1,12 +1,16 @@
 package com.metamong.mt.domain.facility.service;
 
 import com.metamong.mt.domain.facility.dto.request.FacilityRegistrationRequestDto;
+import com.metamong.mt.domain.facility.dto.request.FacilityUpdateRequestDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
 import com.metamong.mt.domain.facility.dto.response.FacilityResponseDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityUpdateResponseDto;
 
 public interface FacilityService {
 
     FacilityRegistrationResponseDto registerFacility(FacilityRegistrationRequestDto dto);
     
     FacilityResponseDto getFacility(Long facilityId);
+    
+    FacilityUpdateResponseDto updateFacility(Long fctId, FacilityUpdateRequestDto dto);
 }

--- a/backend/src/main/java/com/metamong/mt/global/apispec/CommonListUpdateRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/global/apispec/CommonListUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.metamong.mt.global.apispec;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class CommonListUpdateRequestDto<T, ID> {
+    private List<T> create;
+    private List<CommonUpdateListItemRequestDto<T, ID>> update;
+    private List<ID> delete;
+}

--- a/backend/src/main/java/com/metamong/mt/global/apispec/CommonUpdateListItemRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/global/apispec/CommonUpdateListItemRequestDto.java
@@ -1,0 +1,14 @@
+package com.metamong.mt.global.apispec;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class CommonUpdateListItemRequestDto<T, ID> {
+    private ID id;
+    private T to;
+}

--- a/backend/src/test/java/com/metamong/mt/domain/facility/controller/FacilityControllerMockMvcTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/facility/controller/FacilityControllerMockMvcTest.java
@@ -1,8 +1,10 @@
 package com.metamong.mt.domain.facility.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -23,6 +25,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.metamong.mt.domain.facility.dto.response.FacilityRegistrationResponseDto;
+import com.metamong.mt.domain.facility.dto.response.FacilityUpdateResponseDto;
 import com.metamong.mt.domain.facility.dto.response.ImageUploadUrlResponseDto;
 import com.metamong.mt.domain.facility.dto.response.ZoneImageUploadUrlResponseDto;
 import com.metamong.mt.domain.facility.service.FacilityService;
@@ -127,6 +130,81 @@ class FacilityControllerMockMvcTest {
                                         ]
                                     }
                                 ]
+                            }
+                        }
+                        """));
+    }
+    
+    @Test
+    @DisplayName("PUT /api/facilities/{facilityId} - success")
+    void putFacility_success() throws Exception {
+        when(this.facilityService.updateFacility(anyLong(), any()))
+                .thenReturn(new FacilityUpdateResponseDto(
+                        List.of(10L, 20L),
+                        List.of(10L, 20L)));
+        
+        final Long facilityId = 20L;
+        this.mockMvc.perform(put("/api/facilities/{facilityId}", facilityId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "fctName": "FCT",
+                            "fctPostalCode": "01234",
+                            "fctAddress": "Hello",
+                            "fctDetailAddress": "World",
+                            "isOpenOnHolidays": "Y",
+                            "zones": {
+                                "create": [
+                                    {
+                                        "zoneName": "Hello!",
+                                        "maxUserCount": 13,
+                                        "isSharedZone": "Y",
+                                        "hourlyRate": 1500
+                                    },
+                                    {
+                                        "zoneName": "Zone2",
+                                        "maxUserCount": 50,
+                                        "isSharedZone": "N",
+                                        "hourlyRate": 3000
+                                    }
+                                ],
+                                "update": [
+                                    {
+                                        "id": 5,
+                                        "to": {
+                                            "zoneName": "new_zone1",
+                                            "maxUserCount": 13
+                                        }
+                                    }
+                                ],
+                                "delete": [100, 200, 300]
+                            },
+                            "addinfos": {
+                                "create": [
+                                    "newinfo1", "newinfo2"
+                                ],
+                                "update": [
+                                    {
+                                        "id": 500,
+                                        "to": "modified1"
+                                    },
+                                    {
+                                        "id": 501,
+                                        "to": "modified2"
+                                    }
+                                ],
+                                "delete": []
+                            }
+                        }
+                        """))
+                .andDo(print()).andDo(log())
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                        {
+                            "statusCode": 200,
+                            "content": {
+                                "generatedZoneIds": [10, 20],
+                                "generatedAdditionalInfoIds": [10, 20]
                             }
                         }
                         """));


### PR DESCRIPTION
# 설명
시설 수정 API를 미리 정의. 아직 비즈니스 로직은 구현하지 않았다.
또한 collection 업데이트에 사용되는 공통 DTO를 구현하였다.

# 변경사항
- 시설 수정 API 정의
- 시설 수정과 관련된 DTO 구현
- 시설 수정 엔드포인트 테스트 코드 작성
- 업데이트에 사용되는 공통 DTO 구현