### PR TITLE
feat: 카테고리 목록 가져오기 구현

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/facility/controller/CategoryController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/controller/CategoryController.java
@@ -1,0 +1,29 @@
+package com.metamong.mt.domain.facility.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.metamong.mt.domain.facility.dto.response.CategoryListResponseDto;
+import com.metamong.mt.domain.facility.service.CategoryService;
+import com.metamong.mt.global.apispec.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+    
+    @GetMapping("/categories")
+    public ResponseEntity<BaseResponse<List<CategoryListResponseDto>>> getAllCategories() {
+        return ResponseEntity.ok(
+                BaseResponse.of(this.categoryService.getAllCategories(), HttpStatus.OK)
+        );
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/CategoryListResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/CategoryListResponseDto.java
@@ -1,0 +1,33 @@
+package com.metamong.mt.domain.facility.dto.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.metamong.mt.domain.facility.model.Category;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class CategoryListResponseDto {
+    private final String catId;
+    private final String catName;
+    private final List<CategoryListResponseDto> children;
+    
+    public static CategoryListResponseDto of(Category category) {
+        return CategoryListResponseDto.builder()
+                .catId(category.getCatId())
+                .catName(category.getCatName())
+                .children(new ArrayList<>())
+                .build();
+    }
+    
+    public void addChild(CategoryListResponseDto child) {
+        this.children.add(child);
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Category.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Category.java
@@ -50,4 +50,8 @@ public class Category {
     public void addChildCategory(Category childCategory) {
         this.children.add(childCategory);
     }
+    
+    public boolean isRoot() {
+        return this.parentCat == null;
+    }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/CategoryService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/CategoryService.java
@@ -1,0 +1,10 @@
+package com.metamong.mt.domain.facility.service;
+
+import java.util.List;
+
+import com.metamong.mt.domain.facility.dto.response.CategoryListResponseDto;
+
+public interface CategoryService {
+
+    List<CategoryListResponseDto> getAllCategories();
+}

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultCategoryService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultCategoryService.java
@@ -12,15 +12,20 @@ import com.metamong.mt.domain.facility.model.Category;
 import com.metamong.mt.domain.facility.repository.jpa.CategoryRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DefaultCategoryService implements CategoryService {
     private final CategoryRepository categoryRepository;
     
     @Override
     public List<CategoryListResponseDto> getAllCategories() {
         List<Category> allCategories = this.categoryRepository.findAll();
+        if (log.isDebugEnabled()) {
+            log.debug("allCategories={}", allCategories);
+        }
         
         Map<String, CategoryListResponseDto> cache = new HashMap<>();
         Map<String, Category> cache2 = new HashMap<>();

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultCategoryService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultCategoryService.java
@@ -1,0 +1,47 @@
+package com.metamong.mt.domain.facility.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.metamong.mt.domain.facility.dto.response.CategoryListResponseDto;
+import com.metamong.mt.domain.facility.model.Category;
+import com.metamong.mt.domain.facility.repository.jpa.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultCategoryService implements CategoryService {
+    private final CategoryRepository categoryRepository;
+    
+    @Override
+    public List<CategoryListResponseDto> getAllCategories() {
+        List<Category> allCategories = this.categoryRepository.findAll();
+        
+        Map<String, CategoryListResponseDto> cache = new HashMap<>();
+        Map<String, Category> cache2 = new HashMap<>();
+        List<CategoryListResponseDto> result = new ArrayList<>();
+        for (Category category : allCategories) {
+            CategoryListResponseDto dto = CategoryListResponseDto.of(category);
+            if (category.isRoot()) {
+                result.add(dto);
+            }
+            String catId = category.getCatId();
+            cache.put(catId, dto);
+            cache2.put(catId, category);
+        }
+        
+        for (Map.Entry<String, CategoryListResponseDto> entry : cache.entrySet()) {
+            Category category = cache2.get(entry.getKey());
+            if (!category.isRoot()) {
+                String parentId = cache2.get(entry.getKey()).getParentCat().getCatId();
+                cache.get(parentId).addChild(entry.getValue());
+            }
+        }
+        return result;
+    }
+}

--- a/backend/src/test/java/com/metamong/mt/domain/facility/service/DefaultCategoryServiceTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/facility/service/DefaultCategoryServiceTest.java
@@ -1,0 +1,83 @@
+package com.metamong.mt.domain.facility.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metamong.mt.domain.facility.dto.response.CategoryListResponseDto;
+import com.metamong.mt.domain.facility.model.Category;
+import com.metamong.mt.domain.facility.repository.jpa.CategoryRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+class DefaultCategoryServiceTest {
+
+    @InjectMocks
+    DefaultCategoryService categoryService;
+    
+    @Mock
+    CategoryRepository categoryRepository;
+    
+    @Test
+    @DisplayName("getAllCategories() - success")
+    void getAllCategories_success() throws JsonProcessingException {
+        // Given
+        Category root1 = new Category("100", "Root1");
+        Category root2 = new Category("200", "Root2");
+        Category intermediate = new Category("220", "intermediate", root2);
+        List<Category> categories = List.of(
+                new Category("101", "cat1_1", root1),
+                new Category("102", "cat1_2", root1),
+                new Category("103", "cat1_3", root1),
+                new Category("104", "cat1_4", root1),
+                new Category("201", "cat2_1", root2),
+                new Category("202", "cat2_2", root2),
+                new Category("203", "cat2_3", root2),
+                new Category("204", "cat2_4", root2),
+                new Category("205", "cat2_5", root2),
+                root1,
+                root2,
+                intermediate,
+                new Category("221", "leaf", intermediate)
+        );
+        when(this.categoryRepository.findAll())
+                .thenReturn(categories);
+        
+        // When
+        List<CategoryListResponseDto> result = this.categoryService.getAllCategories();
+        
+        ObjectMapper ob = new ObjectMapper();
+        log.info("result:\n{}", ob.writeValueAsString(result));
+        
+        // Then
+        assertThat(result).size().isEqualTo(2);
+        
+        for (CategoryListResponseDto root : result) {
+            if (root.getCatId().equals("100")) {
+                assertThat(root.getChildren().stream().map(CategoryListResponseDto::getCatId))
+                        .containsExactlyInAnyOrder("101", "102", "103", "104");
+            } else if (root.getCatId().equals("200")) {
+                assertThat(root.getChildren().stream().map(CategoryListResponseDto::getCatId))
+                        .containsExactlyInAnyOrder("201", "202", "203", "204", "205", "220");
+                
+                CategoryListResponseDto inter = root.getChildren().stream()
+                        .filter((e) -> e.getCatId().equals("220"))
+                        .findAny()
+                        .orElseThrow(RuntimeException::new);
+                assertThat(inter.getChildren()).size().isEqualTo(1);
+                assertThat(inter.getChildren().get(0).getCatId()).isEqualTo("221");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 설명
카테고리 목록을 모두 가져올 수 있도록 하였답니다.

### 응답 예시
```
{
    "statusCode": 200,
    "message": null,
    "timestamp": "2025-02-07T21:03:04.1248713",
    "content": [
        {
            "catId": "100",
            "catName": "스포츠시설",
            "children": [
                {
                    "catId": "101",
                    "catName": "배드민턴",
                    "children": []
                },
                {
                    "catId": "102",
                    "catName": "풋살",
                    "children": []
                },
                {
                    "catId": "103",
                    "catName": "클라이밍",
                    "children": []
                },
                {
                    "catId": "104",
                    "catName": "탁구장",
                    "children": []
                },
                {
                    "catId": "105",
                    "catName": "당구장",
                    "children": []
                },
                {
                    "catId": "106",
                    "catName": "농구장",
                    "children": []
                }
            ]
        },
        {
            "catId": "200",
            "catName": "레크리에이션시설",
            "children": [
                {
                    "catId": "201",
                    "catName": "강당",
                    "children": []
                },
                {
                    "catId": "202",
                    "catName": "운동장",
                    "children": []
                }
            ]
        }
    ]
}
```

# 변경사항
- 카테고리 목록 가져오기 구현
