### PR TITLE
feat: 시설 등록 화면 데이터 바인딩

### DIFF
--- a/frontend/src/components/facility/AdditionalInformation.vue
+++ b/frontend/src/components/facility/AdditionalInformation.vue
@@ -9,10 +9,12 @@
             {{ $t("facility.addinfoDesc3") }}<br>
             {{ $t("facility.addinfoDesc4") }}
         </p>
-        <div class="input-box" v-for="item in data">
-            <input type="text">
+        <div class="input-box" v-for="(item, idx) in data">
+            <input type="text"
+                   :value="item"
+                   @change="(e) => data[idx] = e.target.value">
         </div>
-        <button type="button">{{ $t("facility.add") }}</button>
+        <button type="button" @click="() => data.push('')">{{ $t("facility.add") }}</button>
     </div>
     <div>
         <button type="button" @click="$emit('component-change', 'zoneRegistrationInput')">{{ $t("facility.previous") }}</button>
@@ -30,7 +32,7 @@ export default {
     },
     data() {
         return {
-            data: {...this.addinfoRegistration}
+            data: this.addinfoRegistration
         }
     },
     methods: {

--- a/frontend/src/components/facility/AdditionalInformation.vue
+++ b/frontend/src/components/facility/AdditionalInformation.vue
@@ -9,7 +9,7 @@
             {{ $t("facility.addinfoDesc3") }}<br>
             {{ $t("facility.addinfoDesc4") }}
         </p>
-        <div class="input-box">
+        <div class="input-box" v-for="item in data">
             <input type="text">
         </div>
         <button type="button">{{ $t("facility.add") }}</button>
@@ -22,6 +22,17 @@
 
 <script>
 export default {
+    props: {
+        addinfoRegistration: {
+            type: Object,
+            required: true
+        }
+    },
+    data() {
+        return {
+            data: {...this.addinfoRegistration}
+        }
+    },
     methods: {
         registerFacility() {
 

--- a/frontend/src/components/facility/FacilityRegistrationInput.vue
+++ b/frontend/src/components/facility/FacilityRegistrationInput.vue
@@ -4,7 +4,10 @@
     </div>
     <div class="container long-input">
         <div class="input-box">
-            <input type="text" :placeholder="$t('facility.facilityName')">
+            <input type="text"
+                   :placeholder="$t('facility.facilityName')"
+                   :value="data.fctName"
+                   @change="(e) => onValueChange(e.target.value, 'fctName')">
         </div>
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.category") }}</h2>
@@ -16,7 +19,7 @@
                         {{ category.catName }}
                     </option>
                 </select>
-                <select>
+                <select @change="(e) => onValueChange(e.target.value, 'minorCatId')">
                     <option>{{ $t("facility.minorCategory") }}</option>
                     <option v-for="minorCategory in selectedMinorCategories"
                             :value="minorCategory.catId"
@@ -30,33 +33,51 @@
             <h2 class="box-title">{{ $t("facility.facilityAddress") }}</h2>
             <div>
                 <div>
-                    <input type="text" :placeholder="$t('facility.postalCode')" :value="data.addr.postalCode" readonly>
+                    <input type="text"
+                           :placeholder="$t('facility.postalCode')"
+                           :value="data.addr.postalCode"
+                           readonly>
                     <button>{{ $t("facility.search") }}</button>
                 </div>
-                <input type="text" :placeholder="$t('facility.address')" :value="data.addr.address" readonly>
-                <input type="text" :placeholder="$t('facility.detailAddress')" :value="data.addr.detailAddress">
+                <input type="text"
+                       :placeholder="$t('facility.address')"
+                       :value="data.addr.address"
+                       readonly>
+                <input type="text"
+                       :placeholder="$t('facility.detailAddress')"
+                       :value="data.addr.detailAddress"
+                       @change="(e) => onValueChange(e.target.value, 'addr.detailAddress')">
             </div>
         </div>
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityTel") }}</h2>
             <div class="tel">
-                <select>
-                    <option value="02" :selected="data.tel.first === '02'">02</option>
-                    <option value="010" :selected="data.tel.first === '010'">010</option>
-                    <option value="011" :selected="data.tel.first === '011'">011</option>
-                    <option value="016" :selected="data.tel.first === '016'">016</option>
-                    <option value="017" :selected="data.tel.first === '017'">017</option>
+                <select @change="(e) => onValueChange(e.target.value, 'tel.first')">
+                    <option value="02"
+                            :selected="data.tel.first === '02'">02</option>
+                    <option value="010"
+                            :selected="data.tel.first === '010'">010</option>
+                    <option value="011"
+                            :selected="data.tel.first === '011'">011</option>
+                    <option value="016"
+                            :selected="data.tel.first === '016'">016</option>
+                    <option value="017"
+                            :selected="data.tel.first === '017'">017</option>
                 </select>
                 <p>-</p>
-                <input type="number" :value="data.tel.second">
+                <input type="number"
+                       :value="data.tel.second"
+                       @change="(e) => onValueChange(e.target.value, 'tel.second')">
                 <p>-</p>
-                <input type="number" :value="data.tel.third">
+                <input type="number"
+                       :value="data.tel.third"
+                       @change="(e) => onValueChange(e.target.value, 'tel.third')">
             </div>
         </div>
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityOperationTime") }}</h2>
             <div>
-                <select>
+                <select @change="(e) => onValueChange(e.target.value, 'operationTime.openTime')">
                     <option v-for="operationTimeSelection in operationTimeSelections"
                             :value="operationTimeSelection"
                             :selected="data.operationTime.openTime">
@@ -64,7 +85,7 @@
                     </option>
                 </select>
                 <p>~</p>
-                <select>
+                <select @change="(e) => onValueChange(e.target.value, 'operationTime.closeTime')">
                     <option v-for="operationTimeSelection in operationTimeSelections"
                             :value="operationTimeSelection"
                             :selected="data.operationTime.closeTime">
@@ -76,20 +97,10 @@
         <div class="input-box">
             <div>
                 <p>{{ $t("facility.isOpenOnHolidays") }}</p>
-            </div>
-            <div>
-                <div>
-                    <input type="radio"
-                           name="isOpenOnHolidays"
-                           :checked="data.isOpenOnHolidays">
-                    <label>{{ $t("facility.yes") }}</label>
-                </div>
-                <div>
-                    <input type="radio"
-                           name="isOpenOnHolidays"
-                           :checked="!data.isOpenOnHolidays">
-                    <label>{{ $t("facility.no") }}</label>
-                </div>
+                <input type="checkbox"
+                        name="isOpenOnHolidays"
+                        :checked="data.isOpenOnHolidays"
+                        @change="(e) => onValueChange(e.target.checked, 'isOpenOnHolidays')">
             </div>
         </div>
         <div class="input-box">
@@ -117,7 +128,7 @@
         </div>
         <div calss="input-box">
             <h2>{{ $t("facility.facilityGuide") }}</h2>
-            <textarea :value="data.guide"></textarea>
+            <textarea :value="data.guide" @change="(e) => onValueChange(e.target.value, 'guide')"></textarea>
         </div>
         <button type="button" @click="$emit('component-change', 'zoneRegistrationInput')">{{ $t("facility.next") }}</button>
     </div>
@@ -150,7 +161,7 @@ export default {
             categories: [],
             selectedMinorCategories: [],
             operationTimeSelections,
-            data: {...this.facilityRegistration}
+            data: this.facilityRegistration
         }
     },
     mounted() {
@@ -161,6 +172,7 @@ export default {
     methods: {
         onChangeMajorCategory(e) {
             console.log(e.target.value);
+            this.onValueChange(e.target.value, "majorCatId");
             for (const major of this.categories) {
                 console.log(major);
                 if (major.catId === e.target.value) {
@@ -186,6 +198,15 @@ export default {
                 console.log(this.data.images);
             }
             fileReader.readAsDataURL(e.target.files[0]);
+        },
+        onValueChange(val, dataRef) {
+            const ladder = dataRef.split(".");
+            let obj = this.data;
+            for (let i = 0; i < ladder.length - 1; i++) {
+                obj = obj[ladder[i]];
+            }
+            obj[ladder[ladder.length - 1]] = val;
+            console.log(this.data);
         }
     }
 };

--- a/frontend/src/components/facility/FacilityRegistrationInput.vue
+++ b/frontend/src/components/facility/FacilityRegistrationInput.vue
@@ -11,14 +11,16 @@
             <div>
                 <select @change="onChangeMajorCategory">
                     <option>{{ $t("facility.majorCategory") }}</option>
-                    <option :value="category.catId" v-for="category in categories">
+                    <option :value="category.catId" v-for="category in categories"
+                            :selected="data.majorCatId === category.catId">
                         {{ category.catName }}
                     </option>
                 </select>
                 <select>
                     <option>{{ $t("facility.minorCategory") }}</option>
                     <option v-for="minorCategory in selectedMinorCategories"
-                            :value="minorCategory.catId">
+                            :value="minorCategory.catId"
+                            :selected="data.minorCatId === minorCategory.catId">
                         {{ minorCategory.catName }}
                     </option>
                 </select>
@@ -28,27 +30,27 @@
             <h2 class="box-title">{{ $t("facility.facilityAddress") }}</h2>
             <div>
                 <div>
-                    <input type="text" :placeholder="$t('facility.postalCode')" readonly>
+                    <input type="text" :placeholder="$t('facility.postalCode')" :value="data.addr.postalCode" readonly>
                     <button>{{ $t("facility.search") }}</button>
                 </div>
-                <input type="text" :placeholder="$t('facility.address')" readonly>
-                <input type="text" :placeholder="$t('facility.detailAddress')" readonly>
+                <input type="text" :placeholder="$t('facility.address')" :value="data.addr.address" readonly>
+                <input type="text" :placeholder="$t('facility.detailAddress')" :value="data.addr.detailAddress">
             </div>
         </div>
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityTel") }}</h2>
             <div class="tel">
                 <select>
-                    <option value="010">02</option>
-                    <option value="010">010</option>
-                    <option value="010">011</option>
-                    <option value="010">016</option>
-                    <option value="010">017</option>
+                    <option value="02" :selected="data.tel.first === '02'">02</option>
+                    <option value="010" :selected="data.tel.first === '010'">010</option>
+                    <option value="011" :selected="data.tel.first === '011'">011</option>
+                    <option value="016" :selected="data.tel.first === '016'">016</option>
+                    <option value="017" :selected="data.tel.first === '017'">017</option>
                 </select>
                 <p>-</p>
-                <input type="number">
+                <input type="number" :value="data.tel.second">
                 <p>-</p>
-                <input type="number">
+                <input type="number" :value="data.tel.third">
             </div>
         </div>
         <div class="input-box">
@@ -56,14 +58,16 @@
             <div>
                 <select>
                     <option v-for="operationTimeSelection in operationTimeSelections"
-                            :value="operationTimeSelection">
+                            :value="operationTimeSelection"
+                            :selected="data.operationTime.openTime">
                         {{ operationTimeSelection }}
                     </option>
                 </select>
                 <p>~</p>
                 <select>
                     <option v-for="operationTimeSelection in operationTimeSelections"
-                            :value="operationTimeSelection">
+                            :value="operationTimeSelection"
+                            :selected="data.operationTime.closeTime">
                         {{ operationTimeSelection }}
                     </option>
                 </select>
@@ -74,12 +78,23 @@
                 <p>{{ $t("facility.isOpenOnHolidays") }}</p>
             </div>
             <div>
-                <input type="radio">
-                <input type="radio">
+                <div>
+                    <input type="radio"
+                           name="isOpenOnHolidays"
+                           :checked="data.isOpenOnHolidays">
+                    <label>{{ $t("facility.yes") }}</label>
+                </div>
+                <div>
+                    <input type="radio"
+                           name="isOpenOnHolidays"
+                           :checked="!data.isOpenOnHolidays">
+                    <label>{{ $t("facility.no") }}</label>
+                </div>
             </div>
         </div>
         <div class="input-box">
-            <input type="number" :placeholder="$t('facility.unitUsageTime')">
+            <input type="number" :placeholder="$t('facility.unitUsageTime')"
+                   :value="data.unitUsageTime">
         </div>
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityImage") }}</h2>
@@ -87,11 +102,13 @@
                 <button>{{ $t("facility.addImage") }}</button>
                 <p>{{ $t("facility.imageLimitDescription") }}</p>
             </div>
-            <div></div>
+            <div>
+                <img v-for="image in data.images">
+            </div>
         </div>
         <div calss="input-box">
             <h2>{{ $t("facility.facilityGuide") }}</h2>
-            <textarea></textarea>
+            <textarea :value="data.guide"></textarea>
         </div>
         <button type="button" @click="$emit('component-change', 'zoneRegistrationInput')">{{ $t("facility.next") }}</button>
     </div>
@@ -101,6 +118,12 @@
 import { get } from "../../apis/axios";
 
 export default {
+    props: {
+        facilityRegistration: {
+            type: Object,
+            required: true
+        }
+    },
     data() {
         const operationTimeSelections = [];
         let minutes = 0;
@@ -117,7 +140,8 @@ export default {
         return {
             categories: [],
             selectedMinorCategories: [],
-            operationTimeSelections
+            operationTimeSelections,
+            data: {...this.facilityRegistration}
         }
     },
     mounted() {

--- a/frontend/src/components/facility/FacilityRegistrationInput.vue
+++ b/frontend/src/components/facility/FacilityRegistrationInput.vue
@@ -114,13 +114,9 @@
                 <p>{{ $t("facility.imageLimitDescription") }}</p>
             </div>
             <div>
-                <input type="file"
-                       ref="file-0"
-                       @change="(e) => onImageUpload(e, 0)"
-                       hidden>
-                <input v-for="(image, index) in this.data.images"
+                <input v-for="(_, index) in fileInput"
                        type="file"
-                       :ref="`file-${index + 1}`"
+                       :ref="`file-${index}`"
                        @change="(e) => onImageUpload(e, index)"
                        hidden>
                 <img v-for="image in data.images" :src="image.fileData">
@@ -161,13 +157,19 @@ export default {
             categories: [],
             selectedMinorCategories: [],
             operationTimeSelections,
-            data: this.facilityRegistration
+            data: this.facilityRegistration,
+            fileInput: []
         }
     },
     mounted() {
         get("/categories").then((response) => {
             this.categories = response.data.content;
         });
+        const a = [];
+        for (let i = 0; i < this.data.images.length + 1; i++) {
+            a.push(0);
+        }
+        this.fileInput = a;
     },
     methods: {
         onChangeMajorCategory(e) {
@@ -185,7 +187,8 @@ export default {
         },
         onAddImageBtnClick() {
             const indexToOpen = this.data.images.length;
-            this.$refs[`file-${indexToOpen}`].click();
+            console.log(this.$refs);
+            this.$refs[`file-${indexToOpen}`][0].click();
         },
         onImageUpload(e, imageNo) {
             const fileReader = new FileReader();
@@ -195,6 +198,7 @@ export default {
                     fileExtension: filename.substring(filename.lastIndexOf(".") + 1),
                     fileData: fileReader.result
                 });
+                this.fileInput.push(0);
                 console.log(this.data.images);
             }
             fileReader.readAsDataURL(e.target.files[0]);

--- a/frontend/src/components/facility/FacilityRegistrationInput.vue
+++ b/frontend/src/components/facility/FacilityRegistrationInput.vue
@@ -99,11 +99,20 @@
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityImage") }}</h2>
             <div>
-                <button>{{ $t("facility.addImage") }}</button>
+                <button @click="onAddImageBtnClick">{{ $t("facility.addImage") }}</button>
                 <p>{{ $t("facility.imageLimitDescription") }}</p>
             </div>
             <div>
-                <img v-for="image in data.images">
+                <input type="file"
+                       ref="file-0"
+                       @change="(e) => onImageUpload(e, 0)"
+                       hidden>
+                <input v-for="(image, index) in this.data.images"
+                       type="file"
+                       :ref="`file-${index + 1}`"
+                       @change="(e) => onImageUpload(e, index)"
+                       hidden>
+                <img v-for="image in data.images" :src="image.fileData">
             </div>
         </div>
         <div calss="input-box">
@@ -161,6 +170,22 @@ export default {
                 }
             }
             return [];
+        },
+        onAddImageBtnClick() {
+            const indexToOpen = this.data.images.length;
+            this.$refs[`file-${indexToOpen}`].click();
+        },
+        onImageUpload(e, imageNo) {
+            const fileReader = new FileReader();
+            fileReader.onload = () => {
+                const filename = e.target.files[0].name;
+                this.data.images.push({
+                    fileExtension: filename.substring(filename.lastIndexOf(".") + 1),
+                    fileData: fileReader.result
+                });
+                console.log(this.data.images);
+            }
+            fileReader.readAsDataURL(e.target.files[0]);
         }
     }
 };

--- a/frontend/src/components/facility/ZoneRegistrationInput.vue
+++ b/frontend/src/components/facility/ZoneRegistrationInput.vue
@@ -3,38 +3,51 @@
         <h1 class="header">{{ $t("facility.zoneRegistration") }}</h1>
     </div>
     <div class="container long-input">
-        <div class="input-box">
-            <input type="text" :placeholder="$t('facility.zoneName')" :value="data.zoneName">
-        </div>
-        <div class="input-box">
-            <input type="text" :placeholder="$t('facility.maxUserCount')" :value="data.maxUserCount">
-        </div>
-        <div class="input-box">
-            <input type="text" :placeholder="$t('facility.hourlyRate')" :value="data.hourlyRate">
-        </div>
-        <div class="input-box">
-            <div>
-                <input type="checkbox" :checked="data.isSharedZone">
-                <label>{{ $t("facility.isSharedZone") }}</label>
+        <div v-for="(zone, zoneIdx) in data">
+            <div class="input-box">
+                <input type="text"
+                    :placeholder="$t('facility.zoneName')"
+                    :value="zone.zoneName"
+                    @change="(e) => onValueChange(zoneIdx, e.target.value, 'zoneName')">
             </div>
-            <p>{{ $t("facility.sharedZoneDescription") }}</p>
-        </div>
-        <div class="input-box">
-            <h2 class="box-title">{{ $t("facility.facilityImage") }}</h2>
-            <div>
-                <button @click="onAddImageBtnClick">{{ $t("facility.addImage") }}</button>
-                <p>{{ $t("facility.imageLimitDescription") }}</p>
+            <div class="input-box">
+                <input type="text"
+                    :placeholder="$t('facility.maxUserCount')"
+                    :value="data.maxUserCount"
+                    @change="(e) => onValueChange(zoneIdx, e.target.value, 'maxUserCount')">
             </div>
-            <div>
-                <input v-for="(_, idx) in fileInputs"
-                       type="file"
-                       :ref="`file-${idx}`"
-                       @change="(e) => onImageUpload(e, index)"
-                       hidden>
-                <img v-for="image in data.images" :src="image.fileData">
+            <div class="input-box">
+                <input type="text"
+                    :placeholder="$t('facility.hourlyRate')"
+                    :value="data.hourlyRate"
+                    @change="(e) => onValueChange(zoneIdx, e.target.value, 'hourlyRate')">
+            </div>
+            <div class="input-box">
+                <div>
+                    <input type="checkbox"
+                        :checked="data.isSharedZone"
+                        @change="(e) => onValueChange(zoneIdx, e.target.checked, 'isSharedZone')">
+                    <label>{{ $t("facility.isSharedZone") }}</label>
+                </div>
+                <p>{{ $t("facility.sharedZoneDescription") }}</p>
+            </div>
+            <div class="input-box">
+                <h2 class="box-title">{{ $t("facility.facilityImage") }}</h2>
+                <div>
+                    <button @click="() => onAddImageBtnClick(zoneIdx)">{{ $t("facility.addImage") }}</button>
+                    <p>{{ $t("facility.imageLimitDescription") }}</p>
+                </div>
+                <div>
+                    <input v-for="(_, idx) in fileInputs"
+                        type="file"
+                        :ref="`file-${zoneIdx}-${idx}`"
+                        @change="(e) => onImageUpload(zoneIdx, e)"
+                        hidden>
+                    <img v-for="image in data[zoneIdx].images" :src="image.fileData">
+                </div>
             </div>
         </div>
-        <!-- TODO: Zone 추가 -->
+        <button type="button" @click="onAddZoneButtonClick">{{ $t("facility.addZone") }}</button>
         <div>
             <button type="button" @click="$emit('component-change', 'facilityRegistrationInput')">{{ $t("facility.previous") }}</button>
             <button type="button" @click="$emit('component-change', 'addinfoRegistrationInput')">{{ $t("facility.next") }}</button>
@@ -52,29 +65,60 @@ export default {
     },
     data() {
         return {
-            data: {...this.zoneRegistration},
-            fileInputs: [0]
+            data: this.zoneRegistration,
+            fileInputs: []
         }
     },
+    mounted() {
+        const a = [];
+        for (let i = 0; i < this.data.length; i++) {
+            const cache = [];
+            for (let j = 0; j < this.data[i].images.length + 1; j++) {
+                cache.push(0);
+            }
+            a.push(cache);
+        }
+        this.fileInputs = a;
+    },
     methods: {
-        onAddImageBtnClick() {
-            const indexToOpen = this.data.images.length;
+        onAddImageBtnClick(zoneIdx) {
+            const indexToOpen = this.data[zoneIdx].images.length;
             console.log(indexToOpen);
             console.log(this.$refs);
-            this.$refs[`file-${indexToOpen}`][0].click();
+            this.$refs[`file-${zoneIdx}-${indexToOpen}`][0].click();
         },
-        onImageUpload(e) {
+        onImageUpload(zoneIdx, e) {
             const fileReader = new FileReader();
             fileReader.onload = () => {
                 const filename = e.target.files[0].name;
-                this.data.images.push({
+                this.data[zoneIdx].images.push({
                     fileExtension: filename.substring(filename.lastIndexOf(".") + 1),
                     fileData: fileReader.result
                 });
-                this.fileInputs.push(0);
-                console.log(this.data.images);
+                this.fileInputs[zoneIdx].push(0);
+                console.log("zoneIdx=" + zoneIdx);
+                console.log(this.data[zoneIdx].images);
             }
             fileReader.readAsDataURL(e.target.files[0]);
+        },
+        onValueChange(zoneIdx, val, dataRef) {
+            const ladder = dataRef.split(".");
+            let obj = this.data[zoneIdx];
+            for (let i = 0; i < ladder.length - 1; i++) {
+                obj = obj[ladder[i]];
+            }
+            obj[ladder[ladder.length - 1]] = val;
+            console.log(this.data);
+        },
+        onAddZoneButtonClick() {
+            this.data.push({
+                zoneName: '',
+                maxUserCount: '',
+                hourlyRate: '',
+                isSharedZone: false,
+                images: []
+            });
+            this.fileInputs.push([0]);
         }
     }
 }

--- a/frontend/src/components/facility/ZoneRegistrationInput.vue
+++ b/frontend/src/components/facility/ZoneRegistrationInput.vue
@@ -22,11 +22,16 @@
         <div class="input-box">
             <h2 class="box-title">{{ $t("facility.facilityImage") }}</h2>
             <div>
-                <button>{{ $t("facility.addImage") }}</button>
+                <button @click="onAddImageBtnClick">{{ $t("facility.addImage") }}</button>
                 <p>{{ $t("facility.imageLimitDescription") }}</p>
             </div>
             <div>
-                <img v-for="image in data.images">
+                <input v-for="(_, idx) in fileInputs"
+                       type="file"
+                       :ref="`file-${idx}`"
+                       @change="(e) => onImageUpload(e, index)"
+                       hidden>
+                <img v-for="image in data.images" :src="image.fileData">
             </div>
         </div>
         <!-- TODO: Zone 추가 -->
@@ -47,7 +52,29 @@ export default {
     },
     data() {
         return {
-            data: {...this.zoneRegistration}
+            data: {...this.zoneRegistration},
+            fileInputs: [0]
+        }
+    },
+    methods: {
+        onAddImageBtnClick() {
+            const indexToOpen = this.data.images.length;
+            console.log(indexToOpen);
+            console.log(this.$refs);
+            this.$refs[`file-${indexToOpen}`][0].click();
+        },
+        onImageUpload(e) {
+            const fileReader = new FileReader();
+            fileReader.onload = () => {
+                const filename = e.target.files[0].name;
+                this.data.images.push({
+                    fileExtension: filename.substring(filename.lastIndexOf(".") + 1),
+                    fileData: fileReader.result
+                });
+                this.fileInputs.push(0);
+                console.log(this.data.images);
+            }
+            fileReader.readAsDataURL(e.target.files[0]);
         }
     }
 }

--- a/frontend/src/components/facility/ZoneRegistrationInput.vue
+++ b/frontend/src/components/facility/ZoneRegistrationInput.vue
@@ -4,17 +4,17 @@
     </div>
     <div class="container long-input">
         <div class="input-box">
-            <input type="text" :placeholder="$t('facility.zoneName')">
+            <input type="text" :placeholder="$t('facility.zoneName')" :value="data.zoneName">
         </div>
         <div class="input-box">
-            <input type="text" :placeholder="$t('facility.maxUserCount')">
+            <input type="text" :placeholder="$t('facility.maxUserCount')" :value="data.maxUserCount">
         </div>
         <div class="input-box">
-            <input type="text" :placeholder="$t('facility.hourlyRate')">
+            <input type="text" :placeholder="$t('facility.hourlyRate')" :value="data.hourlyRate">
         </div>
         <div class="input-box">
             <div>
-                <input type="checkbox">
+                <input type="checkbox" :checked="data.isSharedZone">
                 <label>{{ $t("facility.isSharedZone") }}</label>
             </div>
             <p>{{ $t("facility.sharedZoneDescription") }}</p>
@@ -25,7 +25,9 @@
                 <button>{{ $t("facility.addImage") }}</button>
                 <p>{{ $t("facility.imageLimitDescription") }}</p>
             </div>
-            <div></div>
+            <div>
+                <img v-for="image in data.images">
+            </div>
         </div>
         <!-- TODO: Zone 추가 -->
         <div>
@@ -37,6 +39,16 @@
 
 <script>
 export default {
-    
+    props: {
+        zoneRegistration: {
+            type: Object,
+            required: true
+        }
+    },
+    data() {
+        return {
+            data: {...this.zoneRegistration}
+        }
+    }
 }
 </script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -172,6 +172,8 @@
         "addinfoDesc2": "ex)",
         "addinfoDesc3": "* Showeroom 10h ~ 12h",
         "addinfoDesc4": "* Racket Rent: 1000won",
-        "register": "Register"
+        "register": "Register",
+        "yes": "Yes",
+        "no": "No"
     }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -174,6 +174,7 @@
         "addinfoDesc4": "* Racket Rent: 1000won",
         "register": "Register",
         "yes": "Yes",
-        "no": "No"
+        "no": "No",
+        "addZone": "Add Zone"
     }
 }

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -171,6 +171,8 @@
         "addinfoDesc2": "ex)",
         "addinfoDesc3": "* 샤워장 이용 가능 시간 10h ~ 12h",
         "addinfoDesc4": "* 라켓 대여비: 1000won",
-        "register": "등록"
+        "register": "등록",
+        "yes": "예",
+        "no": "아뇨"
     }
 }

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -173,6 +173,7 @@
         "addinfoDesc4": "* 라켓 대여비: 1000won",
         "register": "등록",
         "yes": "예",
-        "no": "아뇨"
+        "no": "아뇨",
+        "addZone": "Zone 추가"
     }
 }

--- a/frontend/src/pages/facility/FacilityRegistration.vue
+++ b/frontend/src/pages/facility/FacilityRegistration.vue
@@ -21,8 +21,7 @@ import ZoneRegistrationInput from "../../components/facility/ZoneRegistrationInp
 export default {
     data() {
         return {
-            // currentComponent: "facilityRegistrationInput",
-            currentComponent: "addinfoRegistrationInput",
+            currentComponent: "facilityRegistrationInput",
             inputs: {
                 "facilityRegistration": {
                     fctName: "",

--- a/frontend/src/pages/facility/FacilityRegistration.vue
+++ b/frontend/src/pages/facility/FacilityRegistration.vue
@@ -21,9 +21,11 @@ import ZoneRegistrationInput from "../../components/facility/ZoneRegistrationInp
 export default {
     data() {
         return {
-            currentComponent: "facilityRegistrationInput",
+            // currentComponent: "facilityRegistrationInput",
+            currentComponent: "addinfoRegistrationInput",
             inputs: {
                 "facilityRegistration": {
+                    fctName: "",
                     majorCatId: "0",
                     minorCatId: "0",
                     addr: {
@@ -45,13 +47,15 @@ export default {
                     images: [],
                     guide: ""
                 },
-                "zoneRegistration": {
-                    zoneName: "",
-                    maxUserCount: "",
-                    hourlyRate: "",
-                    isSharedZone: false,
-                    images: []
-                },
+                "zoneRegistration": [
+                    {
+                        zoneName: "",
+                        maxUserCount: "",
+                        hourlyRate: "",
+                        isSharedZone: false,
+                        images: []
+                    }
+                ],
                 "addinfoRegistration": []
             }
         };

--- a/frontend/src/pages/facility/FacilityRegistration.vue
+++ b/frontend/src/pages/facility/FacilityRegistration.vue
@@ -1,12 +1,16 @@
 <template>
-    <facility-registration-input v-if="currentComponent === 'facilityRegistrationInput'"
-                                 @component-change="changeComponent" />
+    <facility-registration-input
+        v-if="currentComponent === 'facilityRegistrationInput'"
+        @component-change="changeComponent"
+        :facility-registration="inputs.facilityRegistration" />
     <zone-registration-input
         v-if="currentComponent === 'zoneRegistrationInput'"
-        @component-change="changeComponent" />
+        @component-change="changeComponent"
+        :zone-registration="inputs.zoneRegistration" />
     <additional-information
         v-if="currentComponent === 'addinfoRegistrationInput'"
-        @component-change="changeComponent" />
+        @component-change="changeComponent"
+        :addinfo-registration="inputs.addinfoRegistration" />
 </template>
 
 <script>
@@ -17,7 +21,39 @@ import ZoneRegistrationInput from "../../components/facility/ZoneRegistrationInp
 export default {
     data() {
         return {
-            currentComponent: "facilityRegistrationInput"
+            currentComponent: "facilityRegistrationInput",
+            inputs: {
+                "facilityRegistration": {
+                    majorCatId: "0",
+                    minorCatId: "0",
+                    addr: {
+                        postalCode: "",
+                        address: "",
+                        detailAddress: ""
+                    },
+                    tel: {
+                        first: "02",
+                        second: "",
+                        third: ""
+                    },
+                    operationTime: {
+                        openTime: "",
+                        closeTime: ""
+                    },
+                    isOpenOnHolidays: true,
+                    unitUsageTime: "",
+                    images: [],
+                    guide: ""
+                },
+                "zoneRegistration": {
+                    zoneName: "",
+                    maxUserCount: "",
+                    hourlyRate: "",
+                    isSharedZone: false,
+                    images: []
+                },
+                "addinfoRegistration": []
+            }
         };
     },
     components: {


### PR DESCRIPTION
# 설명
시설 등록 화면은 세 가지 컴포넌트의 전환으로 이루어지는데, 시설 정보 입력, Zone 입력, 추가 정보/서비스 입력이다. 각 컴포넌트 전환 시 데이터가 보존되도록 하였으며, 입력값을 입력할 경우 입력값이 저장되도록 하였다.

### 화면 전환 시 데이터 보존

https://github.com/user-attachments/assets/f7273e4e-7622-486b-96b7-2719ea189055

### Zone 추가

https://github.com/user-attachments/assets/af7ae020-8ad5-4aed-8f40-4f5f0e3a783e


# 변경사항
- 시설 등록 화면 데이터 바인딩
- 화면 전환 시 데이터 보존
- 이미지 추가
