### PR TITLE
fix: 컴파일 에러 및 테스트 코드 에러

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/response/FacilityResponseDto.java
@@ -34,7 +34,6 @@ public class FacilityResponseDto {
     private BooleanAlt isOpenOnHolidays;
     private LocalTime fctOpenTime;
     private LocalTime fctCloseTime;
-    private int unitUsageTime;
     private FacilityState fctState;
     private List<FacilityImageResponseDto> fctImages;
     private List<ZoneResponseDto> zones;

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/service/DefaultReservationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/service/DefaultReservationService.java
@@ -54,7 +54,9 @@ public class DefaultReservationService implements ReservationService {
 
     @Override
     public ReservationResponseDto findReservationByRvtId(Long rvtId) {
-        this.reservationRepository.findById(rvtId).orElseThrow(() -> new ReservationNotFoundException(rvtId, "예약을 찾을 수 없습니다."));
+        if (!this.reservationRepository.existsById(rvtId)) {
+            throw new ReservationNotFoundException(rvtId, "예약을 찾을 수 없습니다.");
+        }
         return this.reservationMapper.findReservationByRvtId(rvtId);
     }
 

--- a/backend/src/test/java/com/metamong/mt/domain/reservation/service/DefaultReservaionServiceTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/reservation/service/DefaultReservaionServiceTest.java
@@ -45,6 +45,7 @@ public class DefaultReservaionServiceTest {
 		dto.setZoneName("Badminton Court");
 		dto.setFctName("Badminton Hall");
 		
+		when(reservationRepository.existsById(1L)).thenReturn(true);
 		when(reservationMapper.findReservationByRvtId(1L)).thenReturn(dto);
         
         // When


### PR DESCRIPTION
# 설명
```FacilityResponseDto```에서 필드가 중복되는 것 때문에 컴파일 에러가 발생하고 있었다. 또한, ```DefaultReservationService.findReservationByRvtId()``` 메소드에서 쿼리 성능이 더 나은 방법으로 개선했다. JPA를 활용하여 데이터베이스에 레코드가 있는지 체크하는 것은 findById보다는 existsById를 사용하는 것이 데이터베이스 IO을 줄여줌으로써 더 나은 성능을 보인다.

# 변경사항
- FacilityResponseDto 컴파일 에러 수정
- DefaultReservationService.findReservationByRvtId() 개선
