### PR TITLE
feat: store에 회원 역할과 회원 이름 추가 저장

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/controller/MemberController.java
@@ -35,6 +35,7 @@ import com.metamong.mt.domain.member.dto.request.PasswordChangeRequestDto;
 import com.metamong.mt.domain.member.dto.request.PasswordConfirmRequestDto;
 import com.metamong.mt.domain.member.dto.request.ProviderSignUpRequestDto;
 import com.metamong.mt.domain.member.dto.request.UpdateRequestDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.exception.InvalidLoginRequestException;
 import com.metamong.mt.domain.member.service.EmailValidationService;
 import com.metamong.mt.domain.member.service.MemberService;
@@ -76,15 +77,15 @@ public class MemberController {
      */
     @PostMapping("/members/login")
     public ResponseEntity<?> login(@Validated @RequestBody LoginRequestDto loginRequest, HttpServletResponse response) {
-        Long memId = this.memberService.login(loginRequest);
+        LoginResponseDto member = this.memberService.login(loginRequest);
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(memId));
+        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(member.getMemId()));
         // 액세스 토큰과 리프레시 토큰 생성
         String accessToken = this.jwtTokenProvider.generateAccessToken(userDetails);
         String refreshToken = this.jwtTokenProvider.generateRefreshToken(userDetails);
 
         // 리프레시 토큰을 DB에 저장
-        this.memberService.updateRefreshToken(memId, refreshToken);
+        this.memberService.updateRefreshToken(member.getMemId(), refreshToken);
 
         // 쿠키 생성
         ResponseCookie accessTokenResponseCookie = this.cookieGenerator.generateCookie("Ws-Access-Token", accessToken);
@@ -111,7 +112,7 @@ public class MemberController {
 
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(BaseResponse.of(memId, HttpStatus.OK, "로그인 성공"));
+                .body(BaseResponse.of(member, HttpStatus.OK, "로그인 성공"));
     }
      
     /**

--- a/backend/src/main/java/com/metamong/mt/domain/member/dto/response/LoginResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/dto/response/LoginResponseDto.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 @Builder
-public class LoginInfoResponseDto {
-    private final String userId;
+public class LoginResponseDto {
+    private final Long memId;
     private final String name;
     private final Role role;
 }

--- a/backend/src/main/java/com/metamong/mt/domain/member/service/DefaultMemberService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/service/DefaultMemberService.java
@@ -2,7 +2,6 @@ package com.metamong.mt.domain.member.service;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,6 +17,7 @@ import com.metamong.mt.domain.member.dto.request.PasswordConfirmRequestDto;
 import com.metamong.mt.domain.member.dto.request.ProviderSignUpRequestDto;
 import com.metamong.mt.domain.member.dto.request.UpdateRequestDto;
 import com.metamong.mt.domain.member.dto.response.BankResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.dto.response.MemberResponseDto;
 import com.metamong.mt.domain.member.exception.EmailAleadyExistException;
 import com.metamong.mt.domain.member.exception.IllegalSignUpRequestException;
@@ -39,7 +39,6 @@ import com.metamong.mt.domain.member.repository.mybatis.MemberMapper;
 import com.metamong.mt.global.constant.BooleanAlt;
 import com.metamong.mt.global.file.FileUploader;
 import com.metamong.mt.global.file.FilenameResolver;
-import com.metamong.mt.global.image.repository.ImageRepository;
 import com.metamong.mt.global.mail.MailAgent;
 import com.metamong.mt.global.mail.MailType;
 
@@ -67,7 +66,7 @@ public class DefaultMemberService implements MemberService {
     
     @Override
     @Transactional(readOnly = true)
-    public Long login(LoginRequestDto dto) {
+    public LoginResponseDto login(LoginRequestDto dto) {
         Member member = null; 
         try {
             member = memberRepository.findByEmail(dto.getEmail())
@@ -83,7 +82,11 @@ public class DefaultMemberService implements MemberService {
             throw new InvalidLoginRequestException(InvalidLoginRequestType.PASSWORD_INCORRECT);
         }
         
-        return member.getMemId();
+        return LoginResponseDto.builder()
+                                   .memId(member.getMemId())
+                                   .name(member.getMemName())
+                                   .role(member.getRole())
+                                   .build();
     }
     
     @Override

--- a/backend/src/main/java/com/metamong/mt/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/service/MemberService.java
@@ -10,16 +10,16 @@ import com.metamong.mt.domain.member.dto.request.PasswordConfirmRequestDto;
 import com.metamong.mt.domain.member.dto.request.ProviderSignUpRequestDto;
 import com.metamong.mt.domain.member.dto.request.UpdateRequestDto;
 import com.metamong.mt.domain.member.dto.response.BankResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.dto.response.MemberResponseDto;
 import com.metamong.mt.domain.member.model.Account;
 import com.metamong.mt.domain.member.model.FctProvider;
 import com.metamong.mt.domain.member.model.Member;
-import com.metamong.mt.domain.member.model.MemberImage;
 
 public interface MemberService {
 
 	// 로그인
-	Long login(LoginRequestDto dto);
+	LoginResponseDto login(LoginRequestDto dto);
 	
 	boolean isValidPassword(Long memId, String password);
 	

--- a/backend/src/test/java/com/metamong/mt/domain/member/controller/MemberControllerMockMvcTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/member/controller/MemberControllerMockMvcTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.metamong.mt.domain.member.dto.response.LoginInfoResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.model.constant.Role;
 import com.metamong.mt.domain.member.service.MemberService;
 import com.metamong.mt.global.auth.jwt.JwtTokenProvider;

--- a/backend/src/test/java/com/metamong/mt/domain/member/controller/SecuredMemberControllerMockMvcTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/member/controller/SecuredMemberControllerMockMvcTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.metamong.mt.domain.member.dto.response.LoginInfoResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.model.constant.Role;
 import com.metamong.mt.domain.member.service.MemberService;
 import com.metamong.mt.global.auth.jwt.JwtTokenProvider;

--- a/backend/src/test/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapperTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.metamong.mt.domain.member.dto.response.LoginInfoResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.model.Member;
 import com.metamong.mt.domain.member.model.constant.Role;
 import com.metamong.mt.domain.member.repository.jpa.MemberRepository;

--- a/backend/src/test/java/com/metamong/mt/domain/member/service/DefaultMemberServiceTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/member/service/DefaultMemberServiceTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.metamong.mt.domain.member.dto.request.LoginRequestDto;
 import com.metamong.mt.domain.member.dto.request.ProviderSignUpRequestDto;
 import com.metamong.mt.domain.member.dto.request.ConsumerSignUpRequestDto;
-import com.metamong.mt.domain.member.dto.response.LoginInfoResponseDto;
+import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
 import com.metamong.mt.domain.member.exception.InvalidLoginRequestException;
 import com.metamong.mt.domain.member.exception.InvalidLoginRequestType;
 import com.metamong.mt.domain.member.exception.PasswordNotConfirmedException;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -17,13 +17,17 @@ const removeUserIdInLocal = function () {
 const store = createStore({
   state: {
     userId: null,
+    userRole: null,
+    userName: null,
     onlineSocket: null,
     onlineUsers: [], // 온라인 사용자 목록
     messages: []  // WebSocket으로 받은 메시지를 저장
   },
   mutations: {
     saveUserId(state, payload) {
-      state.userId = payload;
+      state.userId = payload.memId;
+      state.userRole = payload.role;
+      state.userName = payload.name;
       saveUserIdInLocal(payload);
       if (state.userId === "admin") {
         router.push("/admin");


### PR DESCRIPTION
# 설명
vuex의 store에 역할과 이름을 추가 저장합니다.

# 변경사항
- 로그인 요청 후 회원 아이디, 회원 이름, 역할이 응답됩니다.
- 응답된 데이터를 vuex의 store에 저장합니다.
