### PR TITLE
chore: Jacoco (테스트 코드 커버리지 툴) 추가

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -123,18 +123,18 @@
         
         <!-- WebSocket -->
         <dependency>
-	        <groupId>org.springframework.boot</groupId>
-	        <artifactId>spring-boot-starter-websocket</artifactId>
-    	</dependency>
-    	
-    	<!-- Content Negotiation -->
-    	<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-xml</artifactId>
-		</dependency>
-		
-		<!-- Redis -->
-		<dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        
+        <!-- Content Negotiation -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+        
+        <!-- Redis -->
+        <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
         </dependency>
@@ -152,6 +152,30 @@
     <build>
         <finalName>ROOT</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.8.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
# 설명
테스트 코드 커버리지 툴을 추가하여 한 번 테스트 분석 실행해 봄

![image](https://github.com/user-attachments/assets/02009c9c-9959-4363-a2f5-6b884a41b7d3)

테스트 코드 분석 보고서를 생성하려면 ```./mvnw clean verify```를 입력. 그러면 target/site/jacoco 아래 분석 보고서 (index.html)가 생성된다.
![image](https://github.com/user-attachments/assets/af1a0162-790a-4ab8-a373-4e9151a988a3)

추후, 추가적인 설정이 들어갈 수도

# 변경사항
- Jacoco 추가
