### PR TITLE
feat: 시설 주소에서 위도/경도 가져오기 구현

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -145,10 +145,10 @@
         
         <!-- JSON -->
         <dependency>
-		    <groupId>org.json</groupId>
-		    <artifactId>json</artifactId>
-		    <version>20240303</version>
-		</dependency>
+	    <groupId>org.json</groupId>
+	    <artifactId>json</artifactId>
+	    <version>20240303</version>
+	</dependency>
 
         
         <dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -143,6 +143,14 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         
+        <!-- JSON -->
+        <dependency>
+		    <groupId>org.json</groupId>
+		    <artifactId>json</artifactId>
+		    <version>20240303</version>
+		</dependency>
+
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>

--- a/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityRegistrationRequestDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/dto/request/FacilityRegistrationRequestDto.java
@@ -89,7 +89,6 @@ public class FacilityRegistrationRequestDto {
                 .fctOpenTime(this.getFctOpenTime())
                 .fctCloseTime(this.getFctCloseTime())
                 .unitUsageTime(this.getUnitUsageTime())
-                // TODO: fctLatitude, fctLongitude
                 .build();
     }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/model/Facility.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.metamong.mt.global.constant.BooleanAlt;
+import com.metamong.mt.global.location.LatLng;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -88,5 +89,10 @@ public class Facility {
     
     public void requestDelete() {
         this.fctState = FacilityState.DEL_REQUESTED;
+    }
+    
+    public void updateLatLng(LatLng latLng) {
+        this.fctLatitude = latLng.getLatitude();
+        this.fctLongitude = latLng.getLongitude();
     }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/facility/service/DefaultFacilityService.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.metamong.mt.domain.facility.dto.mapper.FacilityUpdateMapperDto;
 import com.metamong.mt.domain.facility.dto.mapper.ZoneUpdateMapperDto;
 import com.metamong.mt.domain.facility.dto.request.FacilityListRequestDto;
@@ -39,6 +38,7 @@ import com.metamong.mt.global.apispec.CommonListUpdateRequestDto;
 import com.metamong.mt.global.apispec.CommonUpdateListItemRequestDto;
 import com.metamong.mt.global.file.FileUploader;
 import com.metamong.mt.global.file.FilenameResolver;
+import com.metamong.mt.global.location.LocationProvider;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,10 +55,13 @@ public class DefaultFacilityService implements FacilityService {
     private final FilenameResolver filenameResolver;
     private final FileUploader fileUploader;
     private final MemberService memberService;
+    private final LocationProvider locationProvider;
     
     @Override
     public FacilityRegistrationResponseDto registerFacility(FacilityRegistrationRequestDto dto) {
         Facility facility = dto.toEntity();
+        
+        facility.updateLatLng(this.locationProvider.convertAddressToLatLng(dto.getFctAddress()));
         
         List<ImageUploadUrlResponseDto> fctImageUploadUrlResponseDtos = new ArrayList<>(dto.getImages().size());
         for (ImageRequestDto imageRequestDto : dto.getImages()) {

--- a/backend/src/main/java/com/metamong/mt/global/config/BeanConfig.java
+++ b/backend/src/main/java/com/metamong/mt/global/config/BeanConfig.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;

--- a/backend/src/main/java/com/metamong/mt/global/location/AmbiguousAddressException.java
+++ b/backend/src/main/java/com/metamong/mt/global/location/AmbiguousAddressException.java
@@ -1,0 +1,8 @@
+package com.metamong.mt.global.location;
+
+public class AmbiguousAddressException extends RuntimeException {
+
+    public AmbiguousAddressException(String msg) {
+        super(msg);
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/global/location/LatLng.java
+++ b/backend/src/main/java/com/metamong/mt/global/location/LatLng.java
@@ -1,0 +1,13 @@
+package com.metamong.mt.global.location;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class LatLng {
+    private final double latitude;
+    private final double longitude;
+}

--- a/backend/src/main/java/com/metamong/mt/global/location/LocationProvider.java
+++ b/backend/src/main/java/com/metamong/mt/global/location/LocationProvider.java
@@ -1,0 +1,6 @@
+package com.metamong.mt.global.location;
+
+public interface LocationProvider {
+
+    LatLng convertAddressToLatLng(String address) throws AmbiguousAddressException;
+}

--- a/backend/src/main/java/com/metamong/mt/global/location/RestTemplateKakaoLocationProvider.java
+++ b/backend/src/main/java/com/metamong/mt/global/location/RestTemplateKakaoLocationProvider.java
@@ -1,0 +1,59 @@
+package com.metamong.mt.global.location;
+
+import java.net.URI;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class RestTemplateKakaoLocationProvider implements LocationProvider {
+    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+    private static final String REQUEST_URI = "https://dapi.kakao.com/v2/local/search/address";
+    private static final String AUTHORIZATION_PREFIX = "KakaoAK ";
+    
+    private final String kakaoApiKey;
+    
+    public RestTemplateKakaoLocationProvider(@Value("${kakao.rest-api-key}") String kakaoRestApiKey) {
+        this.kakaoApiKey = kakaoRestApiKey;
+    }
+
+    @Override
+    public LatLng convertAddressToLatLng(String address) throws AmbiguousAddressException {
+        URI uri = UriComponentsBuilder.fromHttpUrl(REQUEST_URI)
+                .queryParam("query", address)
+                .encode()
+                .build()
+                .toUri();
+        if (log.isDebugEnabled()) {
+            log.debug("Request URL = {}", uri);
+        }
+        System.out.println(uri);
+        RequestEntity<Void> requestEntity = RequestEntity.get(uri)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_PREFIX + this.kakaoApiKey)
+                .build();
+        
+        String body = REST_TEMPLATE.exchange(requestEntity, String.class).getBody();
+        JSONObject jsonBody = new JSONObject(body);
+        JSONArray documents = jsonBody.getJSONArray("documents");
+        if (documents.length() > 1) {
+            throw new AmbiguousAddressException("모호한 주소 - 결과 개수: " + documents.length());
+        }
+        if (documents.length() < 1)  {
+            throw new IllegalArgumentException("잘못된 주소 - 결과값 없음");
+        }
+        JSONObject addressObj = documents.getJSONObject(0).getJSONObject("address");
+        return new LatLng(
+                Double.parseDouble(addressObj.getString("y")),
+                Double.parseDouble(addressObj.getString("x"))
+        );
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -44,3 +44,6 @@ redis.port=6379
 
 # JWT
 jwt.secret.key=dfsdfsdfsdfsdfsdfsdfs56sdfsdfsdfsf565dsfdfdsfsdf
+
+# Kakao REST API
+kakao.rest-api-key=${KAKAO_REST_API_KEY}

--- a/frontend/src/components/facility/AdditionalInformation.vue
+++ b/frontend/src/components/facility/AdditionalInformation.vue
@@ -14,15 +14,15 @@
         <div class="input-box" v-for="(item, idx) in data">
             <div class="text-input-set mb-3">
                 <input type="text"
-                       :value="isEdit ? item.desc : item"
-                       @change="(e) => isEdit ? data[idx].desc = e.target.value : data[idx] = e.target.value">
+                       :value="isEdit === 'true' ? item.desc : item"
+                       @change="(e) => isEdit === 'true' ? data[idx].desc = e.target.value : data[idx] = e.target.value">
                 <div class="btn-delete"
                         @click="() => data.splice(idx, 1)"><i class="bi bi-trash3-fill"></i></div>
             </div>
         </div>
         <div class="mt-4">
             <button id="addinfo-button" class="w-100 signup-btn rounded-pill mb-3"
-                    type="button" @click="() => isEdit ? data.push({ desc: '' }) : data.push('')">{{ $t("facility.add") }}</button>
+                    type="button" @click="insertAddinfo">{{ $t("facility.add") }}</button>
         </div>
     </div>
 </template>
@@ -42,6 +42,15 @@ export default {
     data() {
         return {
             data: this.addinfoRegistration
+        }
+    },
+    methods: {
+        insertAddinfo() {
+            if (this.isEdit === "true") {
+                this.data.push({ desc: "" });
+            } else {
+                this.data.push("");
+            }
         }
     }
 }

--- a/frontend/src/components/facility/FacilityRegistrationInput.vue
+++ b/frontend/src/components/facility/FacilityRegistrationInput.vue
@@ -199,8 +199,9 @@ export default {
         searchPostCode() {
             new daum.Postcode({
                 oncomplete: (data) => {
-                    this.postalCode = data.zonecode;
-                    this.address = data.userSelectedType === 'R' ? data.address : data.jibunAddress;
+                    console.log(data);
+                    this.data.addr.postalCode = data.zonecode;
+                    this.data.addr.address = data.userSelectedType === 'R' ? data.address : data.jibunAddress;
                 }
             }).open();
         }

--- a/frontend/src/pages/Map.vue
+++ b/frontend/src/pages/Map.vue
@@ -25,7 +25,7 @@ export default {
         } else {
             const script = document.createElement("script");
             script.onload = () => kakao.maps.load(this.initMap);
-            script.src = "//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=ed39086327d2b4332a5533af606ec521&libraries=clusterer";
+            script.src = `//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${import.meta.env.VITE_KAKAO_KEY}&libraries=clusterer`;
             document.head.appendChild(script);
         }
         this.getFctInfo();

--- a/frontend/src/pages/facility/FacilityRegistration.vue
+++ b/frontend/src/pages/facility/FacilityRegistration.vue
@@ -87,8 +87,7 @@ export default {
     },
     computed: {
         userId() {
-            // return this.$store.state.userId;
-            return 21;
+            return this.$store.state.userId;
         }
     },
     methods: {
@@ -101,7 +100,7 @@ export default {
                 fctName: this.inputs.facilityRegistration.fctName,
                 fctPostalCode: this.inputs.facilityRegistration.addr.postalCode,
                 fctAddress: this.inputs.facilityRegistration.addr.address,
-                fctDetailAddress: this.inputs.facilityRegistration.addr.postalCode,
+                fctDetailAddress: this.inputs.facilityRegistration.addr.detailAddress,
                 catId: this.inputs.facilityRegistration.minorCatId ? this.inputs.facilityRegistration.minorCatId : this.inputs.facilityRegistration.majorCatId,
                 provId: this.userId,
                 fctTel: `${this.inputs.facilityRegistration.tel.first}-${this.inputs.facilityRegistration.tel.second}-${this.inputs.facilityRegistration.tel.third}`,

--- a/frontend/src/pages/facility/FacilityRegistration.vue
+++ b/frontend/src/pages/facility/FacilityRegistration.vue
@@ -48,8 +48,8 @@ export default {
                     addr: {
                         // postalCode: "",
                         // address: "",
-                        postalCode: "01234",
-                        address: "ADDR",
+                        postalCode: "",
+                        address: "",
                         detailAddress: ""
                     },
                     tel: {
@@ -87,8 +87,8 @@ export default {
     },
     computed: {
         userId() {
-            return this.$store.state.userId;
-            // return 21;
+            // return this.$store.state.userId;
+            return 21;
         }
     },
     methods: {
@@ -100,7 +100,7 @@ export default {
             const requestBody = {
                 fctName: this.inputs.facilityRegistration.fctName,
                 fctPostalCode: this.inputs.facilityRegistration.addr.postalCode,
-                fctAddress: this.inputs.facilityRegistration.addr.postalCode,
+                fctAddress: this.inputs.facilityRegistration.addr.address,
                 fctDetailAddress: this.inputs.facilityRegistration.addr.postalCode,
                 catId: this.inputs.facilityRegistration.minorCatId ? this.inputs.facilityRegistration.minorCatId : this.inputs.facilityRegistration.majorCatId,
                 provId: this.userId,


### PR DESCRIPTION
# 설명
백엔드에서 시설 주소를 가지고 위도/경도 좌표를 가져오기 구현

환경 변수에 ```KAKAO_REST_API_KEY```를 추가해야 함. (값은 notion의 secret 페이지 안에 있음)

# 변경사항
- 시설 주소를 위도/경도 좌표로 변환 구현
- 추가 정보 입력 버그 수정
