### PR TITLE
feat: 알림 백엔드 완성

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/controller/NotificationController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,6 +45,15 @@ public class NotificationController {
     @PatchMapping("/notifications/read")
     public ResponseEntity<BaseResponse<Void>> readNotifications(@RequestBody List<Long> notificationIds) {
         this.notificationService.readNotifications(notificationIds);
+        return new ResponseEntity<>(
+                BaseResponse.of(HttpStatus.NO_CONTENT),
+                HttpStatus.NO_CONTENT
+        );
+    }
+    
+    @DeleteMapping("/notifications/{notiId}")
+    public ResponseEntity<BaseResponse<Void>> deleteNotification(@PathVariable("notiId") Long notiId) {
+        this.notificationService.deleteById(notiId);
         return new ResponseEntity<>(
                 BaseResponse.of(HttpStatus.NO_CONTENT),
                 HttpStatus.NO_CONTENT

--- a/backend/src/main/java/com/metamong/mt/domain/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/controller/NotificationController.java
@@ -1,0 +1,52 @@
+package com.metamong.mt.domain.notification.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.metamong.mt.domain.notification.dto.response.NotificationResponseDto;
+import com.metamong.mt.domain.notification.service.NotificationService;
+import com.metamong.mt.global.apispec.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping("/members/{memId}/unread-notification-count")
+    public ResponseEntity<BaseResponse<Integer>> countUnread(@PathVariable("memId") Long memId) {
+        return ResponseEntity.ok(
+                BaseResponse.of(this.notificationService.countUnreadNotificationsByReceiverId(memId), HttpStatus.OK)
+        );
+    }
+    
+    @GetMapping("/members/{memId}/notifications")
+    public ResponseEntity<BaseResponse<List<NotificationResponseDto>>> findNotifications(
+            @PathVariable("memId") Long memId,
+            @RequestParam(value = "include-read", defaultValue = "true") boolean includeRead            
+    ) {
+        return ResponseEntity.ok(
+                BaseResponse.of(this.notificationService.findNotifications(memId, includeRead), HttpStatus.OK)
+        );
+    }
+    
+    @PatchMapping("/notifications/read")
+    public ResponseEntity<BaseResponse<Void>> readNotifications(@RequestBody List<Long> notificationIds) {
+        this.notificationService.readNotifications(notificationIds);
+        return new ResponseEntity<>(
+                BaseResponse.of(HttpStatus.NO_CONTENT),
+                HttpStatus.NO_CONTENT
+        );
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/notification/dto/mapper/NotificationListMapperDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/dto/mapper/NotificationListMapperDto.java
@@ -1,0 +1,13 @@
+package com.metamong.mt.domain.notification.dto.mapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class NotificationListMapperDto {
+    private Long receiverId;
+    private boolean includeRead;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/notification/dto/response/NotificationResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/dto/response/NotificationResponseDto.java
@@ -1,0 +1,32 @@
+package com.metamong.mt.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.metamong.mt.domain.notification.model.Notification;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@RequiredArgsConstructor
+@Builder
+@Getter
+@ToString
+public class NotificationResponseDto {
+    private final Long notiId;
+    private final Long receiverId;
+    private final String notiMsg;
+    private final LocalDateTime createdAt;
+    private final boolean read;
+    
+    public static NotificationResponseDto of(Notification notification) {
+        return NotificationResponseDto.builder()
+                .notiId(notification.getNotiId())
+                .receiverId(notification.getReceiverId())
+                .notiMsg(notification.getNotiMsg())
+                .createdAt(notification.getCreatedAt())
+                .read(notification.getIsRead() == 'Y')
+                .build();
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/notification/dto/socket/TextMessageAndUnreadCountMessageDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/dto/socket/TextMessageAndUnreadCountMessageDto.java
@@ -1,0 +1,13 @@
+package com.metamong.mt.domain.notification.dto.socket;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class TextMessageAndUnreadCountMessageDto {
+    private final String message;
+    private final int unreadCount;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/notification/model/Notification.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/model/Notification.java
@@ -15,7 +15,7 @@ import jakarta.persistence.Table;
 @Table(name = "notification")  // 테이블 이름 매핑
 @SequenceGenerator(
         name = "notification_seq",
-        sequenceName = "seq_notification",
+        sequenceName = "noti_pk_seq",
         initialValue = 1,
         allocationSize = 1
 )
@@ -47,6 +47,13 @@ public class Notification {
         this.notiMsg = notiMsg;
         this.createdAt = createdAt;
         this.isRead = isRead;
+    }
+    
+    public Notification(Long receiverId, String notiMsg) {
+        this.receiverId = receiverId;
+        this.notiMsg = notiMsg;
+        this.createdAt = LocalDateTime.now();
+        this.isRead = 'N';
     }
 
     // Getter & Setter

--- a/backend/src/main/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepository.java
@@ -1,9 +1,18 @@
 package com.metamong.mt.domain.notification.repository.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.metamong.mt.domain.notification.model.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>{
 
+    @Query("""
+            SELECT COUNT(*)
+            FROM Notification n
+            WHERE n.receiverId = :receiverId
+                AND n.isRead = 'N'
+            """)
+    int countNotReadNotificationsByReceiverId(@Param("receiverId") Long receiverId);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapper.java
@@ -1,13 +1,14 @@
 package com.metamong.mt.domain.notification.repository.mybatis;
 
-import org.apache.ibatis.annotations.Mapper;
-import org.springframework.stereotype.Repository;
+import java.util.List;
 
-import com.metamong.mt.domain.notification.model.Notification;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @Mapper
 public interface NotificationMapper {
-	//void insertNotification(Notification notification);
-
+	
+    void readByNotificationIds(@Param("readByNotificationIds") List<Long> notificationIds);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapper.java
@@ -6,9 +6,14 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
+import com.metamong.mt.domain.notification.dto.mapper.NotificationListMapperDto;
+import com.metamong.mt.domain.notification.model.Notification;
+
 @Repository
 @Mapper
 public interface NotificationMapper {
 	
     void readByNotificationIds(@Param("readByNotificationIds") List<Long> notificationIds);
+    
+    List<Notification> findNotificationsByReceiverId(@Param("dto") NotificationListMapperDto dto);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
@@ -83,4 +83,9 @@ public class DefaultWebSocketNotificationService implements WebSocketNotificatio
     public void readNotifications(List<Long> notificationIds) {
         this.notificationMapper.readByNotificationIds(notificationIds);
     }
+    
+    @Override
+    public void deleteById(Long notiId) {
+        this.notificationRepository.deleteById(notiId);
+    }
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
@@ -13,4 +13,6 @@ public interface NotificationService {
     List<NotificationResponseDto> findNotifications(Long receiverId, boolean includeRead);
     
     void readNotifications(List<Long> notificationIds);
+    
+    void deleteById(Long notiId);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
@@ -7,12 +7,10 @@ import com.metamong.mt.domain.notification.dto.response.NotificationResponseDto;
 public interface NotificationService {
 
     void sendMessage(Long receiverId, String message);
-
-    void sendMessage(Long receiverId, Object message);
     
-    void sendMessageToAll(String message);
-    
-    void sendMessageToAll(Object message);
+    int countUnreadNotificationsByReceiverId(Long receiverId);
     
     List<NotificationResponseDto> findNotifications(Long receiverId, boolean includeRead);
+    
+    void readNotifications(List<Long> notificationIds);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
@@ -1,12 +1,18 @@
 package com.metamong.mt.domain.notification.service;
 
+import java.util.List;
+
+import com.metamong.mt.domain.notification.dto.response.NotificationResponseDto;
+
 public interface NotificationService {
 
-    void sendMessage(Long memId, String message);
+    void sendMessage(Long receiverId, String message);
 
-    void sendMessage(Long memId, Object message);
+    void sendMessage(Long receiverId, Object message);
     
     void sendMessageToAll(String message);
     
     void sendMessageToAll(Object message);
+    
+    List<NotificationResponseDto> findNotifications(Long receiverId, boolean includeRead);
 }

--- a/backend/src/main/resources/mapper/notification/NotificationMapper.xml
+++ b/backend/src/main/resources/mapper/notification/NotificationMapper.xml
@@ -13,4 +13,21 @@
             </foreach>
     </update>
     
+    <select id="findNotificationsByReceiverId"
+            parameterType="com.metamong.mt.domain.notification.dto.mapper.NotificationListMapperDto"
+            resultType="com.metamong.mt.domain.notification.model.Notification">
+        SELECT
+            noti_id AS "notiId",
+            receiver_id AS "receiverId",
+            noti_msg AS "notiMsg",
+            created_at AS "createdAt",
+            is_read AS "isRead"
+        FROM notification
+        WHERE receiver_id = #{dto.receiverId}
+            <if test="!dto.includeRead">
+                AND is_read = 'N'
+            </if>
+        ORDER BY created_at DESC
+    </select>
+    
 </mapper>

--- a/backend/src/main/resources/mapper/notification/NotificationMapper.xml
+++ b/backend/src/main/resources/mapper/notification/NotificationMapper.xml
@@ -2,10 +2,15 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-
 <mapper namespace="com.metamong.mt.domain.notification.repository.mybatis.NotificationMapper">
-    <insert id="insertNotification" parameterType="com.metamong.mt.domain.notification.model.Notification">
-        INSERT INTO notification (receiver_id, noti_msg, created_at, is_read)
-        VALUES (#{receiverId}, #{notiMsg}, #{createdAt}, #{isRead})
-    </insert>
+    
+    <update id="readByNotificationIds" parameterType="java.util.List">
+        UPDATE notification
+        SET is_read = 'Y'
+        WHERE noti_id IN
+            <foreach collection="readByNotificationIds" item="notiId" open="(" separator="," close=")">
+                #{notiId}
+            </foreach>
+    </update>
+    
 </mapper>

--- a/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.metamong.mt.domain.notification.repository.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import com.metamong.mt.domain.member.model.Member;
+import com.metamong.mt.domain.member.model.constant.Gender;
+import com.metamong.mt.domain.member.model.constant.Role;
+import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
+import com.metamong.mt.domain.notification.model.Notification;
+import com.metamong.mt.global.constant.BooleanAlt;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class NotificationRepositoryTest {
+
+    @Autowired
+    NotificationRepository notificationRepository;
+    
+    @Autowired
+    MemberRepository memberRepository;
+    
+    Member sampleReceiver;
+    
+    @BeforeEach
+    void beforeEach() {
+        this.sampleReceiver = Member.builder()
+                .email("sample@gmail.com")
+                .memName("hello")
+                .password("1q2w3e4r")
+                .memPhone("010-1234-1234")
+                .gender(Gender.M)
+                .birthDate(LocalDate.of(1997, 9, 16))
+                .memPostalCode("12345")
+                .memDetailAddress("where i")
+                .memAddress("hi")
+                .role(Role.ROLE_CONS)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .isDel(BooleanAlt.N)
+                .build();
+        this.sampleReceiver = this.memberRepository.save(this.sampleReceiver);
+    }
+    
+    @Test
+    @DisplayName("countNotReadNotificationsByReceiverId() - success")
+    void countNotReadNotificationsByReceiverId_success() {
+        // Given
+        List<Notification> notifications = List.of(
+                new Notification(this.sampleReceiver.getMemId(), "hi"),
+                new Notification(this.sampleReceiver.getMemId(), "hi1"),
+                new Notification(this.sampleReceiver.getMemId(), "hi2"),
+                new Notification(this.sampleReceiver.getMemId(), "hi3"),
+                new Notification(this.sampleReceiver.getMemId(), "hi4")
+        );
+        
+        notifications.get(0).setIsRead('Y');
+        notifications.get(3).setIsRead('Y');
+        
+        this.notificationRepository.saveAll(notifications);
+        
+        // When
+        int result = this.notificationRepository.countNotReadNotificationsByReceiverId(this.sampleReceiver.getMemId());
+        
+        // Then
+        assertThat(result).isEqualTo(3);
+    }
+}

--- a/backend/src/test/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapperTest.java
@@ -1,0 +1,85 @@
+package com.metamong.mt.domain.notification.repository.mybatis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.metamong.mt.domain.member.model.Member;
+import com.metamong.mt.domain.member.model.constant.Gender;
+import com.metamong.mt.domain.member.model.constant.Role;
+import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
+import com.metamong.mt.domain.notification.model.Notification;
+import com.metamong.mt.domain.notification.repository.jpa.NotificationRepository;
+import com.metamong.mt.global.constant.BooleanAlt;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+class NotificationMapperTest {
+    
+    @Autowired
+    NotificationMapper notificationMapper;
+    
+    @Autowired
+    NotificationRepository notificationRepository;
+    
+    @Autowired
+    MemberRepository memberRepository;
+    
+    Member sampleReceiver;
+    
+    @BeforeEach
+    void beforeEach() {
+        this.sampleReceiver = Member.builder()
+                .email("sample@gmail.com")
+                .memName("hello")
+                .password("1q2w3e4r")
+                .memPhone("010-1234-1234")
+                .gender(Gender.M)
+                .birthDate(LocalDate.of(1997, 9, 16))
+                .memPostalCode("12345")
+                .memDetailAddress("where i")
+                .memAddress("hi")
+                .role(Role.ROLE_CONS)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .isDel(BooleanAlt.N)
+                .build();
+        this.sampleReceiver = this.memberRepository.save(this.sampleReceiver);
+    }
+
+    @Test
+    @DisplayName("countNotReadNotificationsByReceiverId() - success")
+    void countNotReadNotificationsByReceiverId_success() {
+        // Given
+        List<Notification> notifications = List.of(
+                new Notification(this.sampleReceiver.getMemId(), "hi"),
+                new Notification(this.sampleReceiver.getMemId(), "hi1"),
+                new Notification(this.sampleReceiver.getMemId(), "hi2"),
+                new Notification(this.sampleReceiver.getMemId(), "hi3"),
+                new Notification(this.sampleReceiver.getMemId(), "hi4")
+        );
+        
+        this.notificationRepository.saveAll(notifications);
+        
+        this.notificationRepository.flush();
+        
+        // When
+        this.notificationMapper.readByNotificationIds(
+                notifications.stream().map(Notification::getNotiId).toList()
+        );
+        
+        // Then
+        assertThat(this.notificationRepository.countNotReadNotificationsByReceiverId(this.sampleReceiver.getMemId()))
+                .isZero();
+    }
+}


### PR DESCRIPTION
# 설명
알림 백엔드 쪽 완성. 알림과 관련된 여러 기능들 구현

이후 각 도메인에서 어떤 일이 일어날 때마다 알림을 보내는 메소드 (```NotificationService.sendMessage```)를 호출하면 됨

# 변경사항
- 알림 읽기 구현
- 알림 삭제
- 알림 생성
- 알림 가져오기 구현 (안 읽은 알림만 가져올 수도 있고, 읽은 알림 안 읽은 알림 둘 다 가져올 수도 있음) 페이징은 없음
