### PR TITLE
feat: 알림 전송 구현

### DIFF
--- a/backend/src/main/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapper.java
@@ -1,5 +1,6 @@
 package com.metamong.mt.domain.member.repository.mybatis;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -25,4 +26,6 @@ public interface MemberMapper {
 	boolean deleteMember(Long memId);
 	
 	Optional<Long> findMemIdByFctId(@Param("fctId") Long fctId);
+	
+	List<Long> findAllAdminIds();
 }

--- a/backend/src/main/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapper.java
@@ -1,6 +1,9 @@
 package com.metamong.mt.domain.member.repository.mybatis;
 
+import java.util.Optional;
+
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import com.metamong.mt.domain.member.model.Member;
@@ -20,4 +23,6 @@ public interface MemberMapper {
 	
 	// 회원 탈퇴
 	boolean deleteMember(Long memId);
+	
+	Optional<Long> findMemIdByFctId(@Param("fctId") Long fctId);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/dto/response/NotificationResponseDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/dto/response/NotificationResponseDto.java
@@ -24,7 +24,7 @@ public class NotificationResponseDto {
         return NotificationResponseDto.builder()
                 .notiId(notification.getNotiId())
                 .receiverId(notification.getReceiverId())
-                .notiMsg(notification.getNotiMsg())
+                .notiMsg(notification.getNotiMsg().getMessage())
                 .createdAt(notification.getCreatedAt())
                 .read(notification.getIsRead() == 'Y')
                 .build();

--- a/backend/src/main/java/com/metamong/mt/domain/notification/model/Notification.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/model/Notification.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,7 +32,8 @@ public class Notification {
     private Long receiverId;    // 수신자 아이디
 
     @Column(name = "noti_msg", nullable = false)  // 'noti_msg' 컬럼에 매핑
-    private String notiMsg;     // 알림 메시지
+    @Enumerated(EnumType.STRING)
+    private NotificationMessage notiMsg;     // 알림 메시지
 
     @Column(name = "created_at", nullable = false)  // 'created_at' 컬럼에 매핑
     private LocalDateTime createdAt;  // 등록 시간
@@ -42,14 +45,14 @@ public class Notification {
     public Notification() {}
 
     // 생성자
-    public Notification(Long receiverId, String notiMsg, LocalDateTime createdAt, Character isRead) {
+    public Notification(Long receiverId, NotificationMessage notiMsg, LocalDateTime createdAt, Character isRead) {
         this.receiverId = receiverId;
         this.notiMsg = notiMsg;
         this.createdAt = createdAt;
         this.isRead = isRead;
     }
     
-    public Notification(Long receiverId, String notiMsg) {
+    public Notification(Long receiverId, NotificationMessage notiMsg) {
         this.receiverId = receiverId;
         this.notiMsg = notiMsg;
         this.createdAt = LocalDateTime.now();
@@ -73,11 +76,11 @@ public class Notification {
         this.receiverId = receiverId;
     }
 
-    public String getNotiMsg() {
+    public NotificationMessage getNotiMsg() {
         return notiMsg;
     }
 
-    public void setNotiMsg(String notiMsg) {
+    public void setNotiMsg(NotificationMessage notiMsg) {
         this.notiMsg = notiMsg;
     }
 

--- a/backend/src/main/java/com/metamong/mt/domain/notification/model/NotificationMessage.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/model/NotificationMessage.java
@@ -1,0 +1,27 @@
+package com.metamong.mt.domain.notification.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+public enum NotificationMessage {
+    // Reservation
+    RESERVATION_CHECK_ONE_HOUR_REMAIN("예약이 1시간 남았습니다"),
+    RESERVATION_CANCELATION("예약이 취소됐습니다"),
+    NEW_RESERVATION("새로운 예약이 있습니다"),
+    
+    // Facility
+    FACILITY_REGISTRATION_ACCEPTED("시설 등록이 승인됐습니다"),
+    FACILITY_REGISTRATION_REJECTED("시설 등록이 거절됐습니다"),
+    FACILITY_DELETION_ACCEPTED("시설 삭제 요청이 승인되었습니다"),
+    FACILITY_DELETION_REJECTED("시설 삭제 요청이 반려되었습니다"),
+    
+    // Refund
+    REFUND_REJECTED("환불 요청이 거절됐습니다"),
+    NEW_REFUND_REQUEST("새로운 환불 요청이 있습니다"),
+    REFUND_ACCEPT("환불 요청이 승인됐습니다");
+    
+    private final String message;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/notification/model/NotificationMessage.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/model/NotificationMessage.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public enum NotificationMessage {
     // Reservation
     RESERVATION_CHECK_ONE_HOUR_REMAIN("예약이 1시간 남았습니다"),
+    RESERVATION_CHECK_ONE_DAY_REMAIN("예약이 1일 남았습니다"),
     RESERVATION_CANCELATION("예약이 취소됐습니다"),
     NEW_RESERVATION("새로운 예약이 있습니다"),
     

--- a/backend/src/main/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepository.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.metamong.mt.domain.notification.repository.jpa;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                 AND n.isRead = 'N'
             """)
     int countNotReadNotificationsByReceiverId(@Param("receiverId") Long receiverId);
+    
+    @Modifying
+    @Query(value = """
+            UPDATE notification
+            SET is_read = 'Y'
+            WHERE receiver_id = :receiverId
+            """, nativeQuery = true)
+    void readAllNotificationsByReceiverId(@Param("receiverId") Long receiverId);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
@@ -74,6 +74,7 @@ public class DefaultWebSocketNotificationService implements WebSocketNotificatio
     
     @Override
     public List<NotificationResponseDto> findNotifications(Long receiverId, boolean includeRead) {
+        this.notificationRepository.readAllNotificationsByReceiverId(receiverId);
         return this.notificationMapper.findNotificationsByReceiverId(new NotificationListMapperDto(receiverId, includeRead))
                 .stream()
                 .map(NotificationResponseDto::of)

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/DefaultWebSocketNotificationService.java
@@ -14,6 +14,7 @@ import com.metamong.mt.domain.notification.dto.response.NotificationResponseDto;
 import com.metamong.mt.domain.notification.dto.socket.TextMessageAndUnreadCountMessageDto;
 import com.metamong.mt.domain.notification.exception.FailedNotificationTransmissionException;
 import com.metamong.mt.domain.notification.model.Notification;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
 import com.metamong.mt.domain.notification.repository.WebSocketSessionRepository;
 import com.metamong.mt.domain.notification.repository.jpa.NotificationRepository;
 import com.metamong.mt.domain.notification.repository.mybatis.NotificationMapper;
@@ -31,14 +32,14 @@ public class DefaultWebSocketNotificationService implements WebSocketNotificatio
     private final ObjectMapper objectMapper;
     
     @Override
-    public void sendMessage(Long receiverId, String message) {
-        saveNotification(receiverId, message);
+    public void sendMessage(Long receiverId, NotificationMessage notiMsg) {
+        saveNotification(receiverId, notiMsg);
         this.webSocketSessionRepository.findByMemId(receiverId)
                 .ifPresent((session) -> {
                     try {
                         int unreadCount = this.countUnreadNotificationsByReceiverId(receiverId);
                         String messageInJson =
-                                this.objectMapper.writeValueAsString(new TextMessageAndUnreadCountMessageDto(message, unreadCount));
+                                this.objectMapper.writeValueAsString(new TextMessageAndUnreadCountMessageDto(notiMsg.getMessage(), unreadCount));
                         session.sendMessage(new TextMessage(messageInJson));
                     } catch (IOException e) {
                         throw new FailedNotificationTransmissionException(e);
@@ -46,10 +47,10 @@ public class DefaultWebSocketNotificationService implements WebSocketNotificatio
                 });
     }
     
-    private Notification saveNotification(Long receiverId, String message) {
+    private Notification saveNotification(Long receiverId, NotificationMessage notiMsg) {
         Notification newNotification = new Notification(
                 receiverId,
-                message,
+                notiMsg,
                 LocalDateTime.now(),
                 'N'
         );

--- a/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/notification/service/NotificationService.java
@@ -3,10 +3,11 @@ package com.metamong.mt.domain.notification.service;
 import java.util.List;
 
 import com.metamong.mt.domain.notification.dto.response.NotificationResponseDto;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
 
 public interface NotificationService {
 
-    void sendMessage(Long receiverId, String message);
+    void sendMessage(Long receiverId, NotificationMessage notificationType);
     
     int countUnreadNotificationsByReceiverId(Long receiverId);
     

--- a/backend/src/main/java/com/metamong/mt/domain/payment/service/DefaultPaymentService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/payment/service/DefaultPaymentService.java
@@ -7,6 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.metamong.mt.domain.member.model.Account;
 import com.metamong.mt.domain.member.repository.jpa.AccountRepository;
+import com.metamong.mt.domain.member.repository.mybatis.MemberMapper;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
+import com.metamong.mt.domain.notification.service.NotificationService;
 import com.metamong.mt.domain.payment.dto.response.PaymentResponseDto;
 import com.metamong.mt.domain.payment.exception.AccountNotFoundException;
 import com.metamong.mt.domain.payment.exception.NotEnoughMoneyException;
@@ -26,6 +29,8 @@ public class DefaultPaymentService implements PaymentService{
     private final PaymentMapper paymentMapper;
     private final PaymentRepository paymentRepository;
     private final AccountRepository accountRepository;
+    private final NotificationService notificationService;
+    private final MemberMapper memberMapper;
     
     @Override
     @Transactional
@@ -53,6 +58,8 @@ public class DefaultPaymentService implements PaymentService{
     @Override
     public void reservationCancelRequest(Long rvtId, CancelRequestDto dto) {
         this.getPaymentByRepository(rvtId).reservationCancelRequest(dto);
+        this.memberMapper.findAllAdminIds()
+                .forEach((adminId) -> this.notificationService.sendMessage(adminId, NotificationMessage.NEW_REFUND_REQUEST));
     }
 
     @Override

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/dto/mapper/FindConsIdWithReservationTimeMapperDto.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/dto/mapper/FindConsIdWithReservationTimeMapperDto.java
@@ -1,0 +1,17 @@
+package com.metamong.mt.domain.reservation.dto.mapper;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class FindConsIdWithReservationTimeMapperDto {
+    private int leftReservationTimeInHour;
+    private LocalDateTime criteriaTime;
+}

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapper.java
@@ -1,6 +1,7 @@
 package com.metamong.mt.domain.reservation.repository.mybatis;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.repository.query.Param;
@@ -31,4 +32,6 @@ public interface ReservationMapper {
     List<HourlyUsageDto> getReservedTimes(SelectedInfoRequestDto dto);
     
     List<Long> findConsIdWithLeftReservationTime(@Param("dto") FindConsIdWithReservationTimeMapperDto dto);
+    
+    Optional<Long> findProvIdByRvtId(@Param("rvtId") Long rvtId);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapper.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.metamong.mt.domain.reservation.dto.mapper.FindConsIdWithReservationTimeMapperDto;
 import com.metamong.mt.domain.reservation.dto.request.ReservationRequestDto;
 import com.metamong.mt.domain.reservation.dto.request.SelectedInfoRequestDto;
 import com.metamong.mt.domain.reservation.dto.response.HourlyUsageDto;
@@ -28,4 +29,6 @@ public interface ReservationMapper {
     List<HourlyUsageDto> getHourlyUsageCounts(ReservationRequestDto dto);
     
     List<HourlyUsageDto> getReservedTimes(SelectedInfoRequestDto dto);
+    
+    List<Long> findConsIdWithLeftReservationTime(@Param("dto") FindConsIdWithReservationTimeMapperDto dto);
 }

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/scheduler/ReservationScheduler.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/scheduler/ReservationScheduler.java
@@ -1,0 +1,39 @@
+package com.metamong.mt.domain.reservation.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.metamong.mt.domain.notification.model.NotificationMessage;
+import com.metamong.mt.domain.notification.service.NotificationService;
+import com.metamong.mt.domain.reservation.dto.mapper.FindConsIdWithReservationTimeMapperDto;
+import com.metamong.mt.domain.reservation.repository.mybatis.ReservationMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationScheduler {
+    private final NotificationService notificationService;
+    private final ReservationMapper reservationMapper;
+
+    /**
+     * <p>1시간마다 예약 알림을 전송한다.
+     * 
+     * <p>예약이 1시간 남은 사람과
+     * 예약이 1일 남은 사람에게 예약 알림을 전송
+     */
+    @Scheduled(cron = "0 0 0/1 * * *")
+    public void sendReservationNotification() {
+        LocalDateTime now = LocalDateTime.now();
+        
+        this.reservationMapper.findConsIdWithLeftReservationTime(
+                new FindConsIdWithReservationTimeMapperDto(1, now)
+        ).forEach((consId) -> this.notificationService.sendMessage(consId, NotificationMessage.RESERVATION_CHECK_ONE_HOUR_REMAIN));
+        
+        this.reservationMapper.findConsIdWithLeftReservationTime(
+                new FindConsIdWithReservationTimeMapperDto(24, now)
+        ).forEach((consId) -> this.notificationService.sendMessage(consId, NotificationMessage.RESERVATION_CHECK_ONE_HOUR_REMAIN));
+    }
+}

--- a/backend/src/main/java/com/metamong/mt/domain/reservation/service/DefaultReservationService.java
+++ b/backend/src/main/java/com/metamong/mt/domain/reservation/service/DefaultReservationService.java
@@ -5,12 +5,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.metamong.mt.domain.facility.model.Facility;
 import com.metamong.mt.domain.facility.repository.jpa.FacilityRepository;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
+import com.metamong.mt.domain.notification.service.NotificationService;
 import com.metamong.mt.domain.payment.model.Payment;
 import com.metamong.mt.domain.payment.service.PaymentService;
 import com.metamong.mt.domain.reservation.dto.request.CancelRequestDto;
@@ -39,6 +42,7 @@ public class DefaultReservationService implements ReservationService {
     private final ReservationRepository reservationRepository;
     private final FacilityRepository facilityRepository;
     private final PaymentService paymentService;
+    private final NotificationService notificationService;
     private static final int PAGE_SIZE = 5;
     
     @Override
@@ -139,6 +143,10 @@ public class DefaultReservationService implements ReservationService {
         }
         Reservation savedReservation = this.reservationRepository.saveAndFlush(reservationDto);
         this.paymentService.savePayment(savedReservation.getRvtId(), paymentDto);
+        
+        Long provIdOfFacility = this.reservationMapper.findProvIdByRvtId(savedReservation.getRvtId())
+                .orElseThrow(NoSuchElementException::new);
+        this.notificationService.sendMessage(provIdOfFacility, NotificationMessage.NEW_RESERVATION);
     }
 
     @Override

--- a/backend/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/src/main/resources/mapper/member/MemberMapper.xml
@@ -63,4 +63,10 @@
         WHERE f.fct_id = #{fctId}
     </select>
 
+    <select id="findAllAdminIds" resultType="java.lang.Long">
+        SELECT
+            mem_id
+        FROM member
+        WHERE role = 'ROLE_ADMN'
+    </select>
 </mapper>

--- a/backend/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/src/main/resources/mapper/member/MemberMapper.xml
@@ -53,5 +53,14 @@
         UPDATE member SET is_del='Y' WHERE mem_id=#{memId}
     ]]>
     </update>
+    
+    <select id="findMemIdByFctId" parameterType="java.lang.Long" resultType="java.lang.Long">
+        SELECT
+            m.mem_id
+        FROM member m
+        INNER JOIN fct_provider fp ON fp.prov_id = m.mem_id
+        INNER JOIN facility f ON f.prov_id = fp.prov_id
+        WHERE f.fct_id = #{fctId}
+    </select>
 
 </mapper>

--- a/backend/src/main/resources/mapper/reservation/ReservationMapper.xml
+++ b/backend/src/main/resources/mapper/reservation/ReservationMapper.xml
@@ -125,4 +125,13 @@
         WHERE TO_DATE(TO_CHAR(rvt_date, 'yyyy-MM-DD') || ' ' || TO_CHAR(usage_start_time, 'HH24:MI:SS'), 'yyyy-MM-dd HH24:MI:SS') <= #{criteriaTime} + INTERVAL '1' HOUR * #{leftReservationTimeInHour} 
         ]]>
     </select>
+    
+    <select id="findProvIdByRvtId" parameterType="java.lang.Long" resultType="java.lang.Long">
+        SELECT
+            f.prov_id
+        FROM reservation r
+        INNER JOIN zone z ON z.zone_id = r.zone_id
+        INNER JOIN facility f ON f.fct_id = z.fct_id
+        WHERE r.rvt_id = #{rvtId}
+    </select>
 </mapper>

--- a/backend/src/main/resources/mapper/reservation/ReservationMapper.xml
+++ b/backend/src/main/resources/mapper/reservation/ReservationMapper.xml
@@ -117,4 +117,12 @@
         ]]>
     </select>
 
+    <select id="findConsIdWithLeftReservationTime" parameterType="com.metamong.mt.domain.reservation.dto.mapper.FindConsIdWithReservationTimeMapperDto" resultType="java.lang.Long">
+        SELECT
+            cons_id
+        FROM reservation
+        <![CDATA[
+        WHERE TO_DATE(TO_CHAR(rvt_date, 'yyyy-MM-DD') || ' ' || TO_CHAR(usage_start_time, 'HH24:MI:SS'), 'yyyy-MM-dd HH24:MI:SS') <= #{criteriaTime} + INTERVAL '1' HOUR * #{leftReservationTimeInHour} 
+        ]]>
+    </select>
 </mapper>

--- a/backend/src/test/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/facility/repository/mybatis/FacilityMapperTest.java
@@ -88,7 +88,7 @@ class FacilityMapperTest {
     
     @BeforeEach
     void initData() throws Exception {
-     // Given
+        // Given
         Connection conn = null;
         PreparedStatement stmt = null;
         

--- a/backend/src/test/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/member/repository/mybatis/MemberMapperTest.java
@@ -2,21 +2,34 @@ package com.metamong.mt.domain.member.repository.mybatis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.metamong.mt.domain.member.dto.response.LoginResponseDto;
+import com.metamong.mt.domain.facility.model.Category;
+import com.metamong.mt.domain.facility.model.Facility;
+import com.metamong.mt.domain.facility.model.FacilityState;
+import com.metamong.mt.domain.facility.repository.jpa.CategoryRepository;
+import com.metamong.mt.domain.facility.repository.jpa.FacilityRepository;
+import com.metamong.mt.domain.member.model.FctProvider;
 import com.metamong.mt.domain.member.model.Member;
+import com.metamong.mt.domain.member.model.constant.Gender;
 import com.metamong.mt.domain.member.model.constant.Role;
+import com.metamong.mt.domain.member.repository.jpa.FctProviderRepository;
 import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
-import com.metamong.mt.domain.member.repository.mybatis.MemberMapper;
-import com.metamong.mt.testutil.DummyEntityGenerator;
+import com.metamong.mt.global.constant.BooleanAlt;
 
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
+@Transactional
 @Slf4j
 class MemberMapperTest {
     
@@ -25,6 +38,18 @@ class MemberMapperTest {
     
     @Autowired
     MemberRepository memberRepository;
+    
+    @Autowired
+    FctProviderRepository fctProviderRepository;
+    
+    @Autowired
+    CategoryRepository categoryRepository;
+    
+    @Autowired
+    FacilityRepository facilityRepository;
+    
+    @Autowired
+    EntityManager entityManager;
 //
 //    @Test
 //    @DisplayName("findLoginInfoByUserId() - 성공")
@@ -44,4 +69,61 @@ class MemberMapperTest {
 //        assertThat(result.getName()).isEqualTo(dummyName);
 //        assertThat(result.getRole()).isEqualTo(dummyRole);
 //    }
+    
+    @Test
+    @DisplayName("findMemIdByFctId() - success")
+    void findMemIdByFctId_success() {
+        // Given
+        Member member = Member.builder()
+                .email("test@gmail.com")
+                .memName("test")
+                .password("1q2w3e4r")
+                .memPhone("010-1234-1234")
+                .gender(Gender.M)
+                .birthDate(LocalDate.of(1997, 9, 16))
+                .memPostalCode("12345")
+                .memDetailAddress("daddr")
+                .memAddress("addr")
+                .role(Role.ROLE_PROV)
+                .build();
+        member = this.memberRepository.save(member);
+        
+        FctProvider fctProvider = FctProvider.builder()
+                .provId(member.getMemId())
+                .bizName("BIZ")
+                .bizRegNum("1234-152414")
+                .build();
+        fctProvider = this.fctProviderRepository.save(fctProvider);
+        
+        Category category = new Category("011", "CAT");
+        category = this.categoryRepository.save(category);
+        
+        Facility facility = Facility.builder()
+                .cat(category)
+                .fctName("FCT")
+                .provId(fctProvider.getProvId())
+                .fctPostalCode("41242")
+                .fctAddress("hello")
+                .fctDetailAddress("goodbye")
+                .fctTel("02-1234-1234")
+                .fctGuide("Why so serious")
+                .openOnHolidays(BooleanAlt.N)
+                .fctOpenTime(LocalTime.of(12, 0))
+                .fctCloseTime(LocalTime.of(18, 5))
+                .unitUsageTime(50)
+                .fctState(FacilityState.REG_APPROVED)
+                .fctLatitude(36.1343141)
+                .fctLongitude(128.315135)
+                .build();
+        facility = this.facilityRepository.save(facility);
+        
+        this.entityManager.flush();
+        
+        // When
+        Optional<Long> result = this.memberMapper.findMemIdByFctId(facility.getFctId());
+        
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.get()).isEqualTo(member.getMemId());
+    }
 }

--- a/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.metamong.mt.domain.notification.repository.jpa;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
 import com.metamong.mt.domain.member.model.Member;
 import com.metamong.mt.domain.member.model.constant.Gender;
 import com.metamong.mt.domain.member.model.constant.Role;
@@ -19,6 +21,8 @@ import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
 import com.metamong.mt.domain.notification.model.Notification;
 import com.metamong.mt.domain.notification.model.NotificationMessage;
 import com.metamong.mt.global.constant.BooleanAlt;
+
+import jakarta.persistence.EntityManager;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -29,6 +33,9 @@ class NotificationRepositoryTest {
     
     @Autowired
     MemberRepository memberRepository;
+    
+    @Autowired
+    EntityManager entityManager;
     
     Member sampleReceiver;
     
@@ -74,5 +81,32 @@ class NotificationRepositoryTest {
         
         // Then
         assertThat(result).isEqualTo(3);
+    }
+    
+    @Test
+    @DisplayName("어떤 회원의 모든 알림 읽기 - success")
+    void readAllNotificationsByReceiverId_success() {
+        // Given
+        List<Notification> notifications = List.of(
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_ACCEPTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_REJECTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_ACCEPT),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.RESERVATION_CANCELATION),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_REJECTED)
+        );
+        
+        this.notificationRepository.saveAll(notifications);
+        
+        this.entityManager.flush();
+        
+        int unreadBefore = this.notificationRepository.countNotReadNotificationsByReceiverId(this.sampleReceiver.getMemId());
+        assertThat(unreadBefore).isEqualTo(notifications.size());
+        
+        // When
+        this.notificationRepository.readAllNotificationsByReceiverId(this.sampleReceiver.getMemId());;
+        
+        // Then
+        int unreadAfter = this.notificationRepository.countNotReadNotificationsByReceiverId(this.sampleReceiver.getMemId());
+        assertThat(unreadAfter).isZero();
     }
 }

--- a/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/notification/repository/jpa/NotificationRepositoryTest.java
@@ -17,6 +17,7 @@ import com.metamong.mt.domain.member.model.constant.Gender;
 import com.metamong.mt.domain.member.model.constant.Role;
 import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
 import com.metamong.mt.domain.notification.model.Notification;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
 import com.metamong.mt.global.constant.BooleanAlt;
 
 @DataJpaTest
@@ -56,11 +57,11 @@ class NotificationRepositoryTest {
     void countNotReadNotificationsByReceiverId_success() {
         // Given
         List<Notification> notifications = List.of(
-                new Notification(this.sampleReceiver.getMemId(), "hi"),
-                new Notification(this.sampleReceiver.getMemId(), "hi1"),
-                new Notification(this.sampleReceiver.getMemId(), "hi2"),
-                new Notification(this.sampleReceiver.getMemId(), "hi3"),
-                new Notification(this.sampleReceiver.getMemId(), "hi4")
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_ACCEPTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_REJECTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_ACCEPT),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.RESERVATION_CANCELATION),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_REJECTED)
         );
         
         notifications.get(0).setIsRead('Y');

--- a/backend/src/test/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/notification/repository/mybatis/NotificationMapperTest.java
@@ -18,6 +18,7 @@ import com.metamong.mt.domain.member.model.constant.Role;
 import com.metamong.mt.domain.member.repository.jpa.MemberRepository;
 import com.metamong.mt.domain.notification.dto.mapper.NotificationListMapperDto;
 import com.metamong.mt.domain.notification.model.Notification;
+import com.metamong.mt.domain.notification.model.NotificationMessage;
 import com.metamong.mt.domain.notification.repository.jpa.NotificationRepository;
 import com.metamong.mt.global.constant.BooleanAlt;
 
@@ -63,11 +64,11 @@ class NotificationMapperTest {
     void countNotReadNotificationsByReceiverId_success() {
         // Given
         List<Notification> notifications = List.of(
-                new Notification(this.sampleReceiver.getMemId(), "hi"),
-                new Notification(this.sampleReceiver.getMemId(), "hi1"),
-                new Notification(this.sampleReceiver.getMemId(), "hi2"),
-                new Notification(this.sampleReceiver.getMemId(), "hi3"),
-                new Notification(this.sampleReceiver.getMemId(), "hi4")
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_ACCEPTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_REJECTED),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_ACCEPT),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.RESERVATION_CANCELATION),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_REJECTED)
         );
         
         this.notificationRepository.saveAll(notifications);
@@ -90,11 +91,11 @@ class NotificationMapperTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         List<Notification> notifications = List.of(
-                new Notification(this.sampleReceiver.getMemId(), "hi", now.plusHours(2), 'Y'),
-                new Notification(this.sampleReceiver.getMemId(), "hi1", now.plusHours(3), 'N'),
-                new Notification(this.sampleReceiver.getMemId(), "hi2", now.plusHours(1), 'N'),
-                new Notification(this.sampleReceiver.getMemId(), "hi3", now.plusHours(4), 'Y'),
-                new Notification(this.sampleReceiver.getMemId(), "hi4", now, 'N')
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_ACCEPTED, now.plusHours(2), 'Y'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_REJECTED, now.plusHours(3), 'N'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_ACCEPT,  now.plusHours(1), 'N'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.RESERVATION_CANCELATION, now.plusHours(4), 'Y'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_REJECTED, now, 'N')
         );
         
         notifications.get(0).setIsRead('Y');
@@ -132,11 +133,11 @@ class NotificationMapperTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         List<Notification> notifications = List.of(
-                new Notification(this.sampleReceiver.getMemId(), "hi", now.plusHours(2), 'Y'),
-                new Notification(this.sampleReceiver.getMemId(), "hi1", now.plusHours(3), 'N'),
-                new Notification(this.sampleReceiver.getMemId(), "hi2", now.plusHours(1), 'N'),
-                new Notification(this.sampleReceiver.getMemId(), "hi3", now.plusHours(4), 'Y'),
-                new Notification(this.sampleReceiver.getMemId(), "hi4", now, 'N')
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_ACCEPTED, now.plusHours(2), 'Y'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.FACILITY_REGISTRATION_REJECTED, now.plusHours(3), 'N'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_ACCEPT,  now.plusHours(1), 'N'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.RESERVATION_CANCELATION, now.plusHours(4), 'Y'),
+                new Notification(this.sampleReceiver.getMemId(), NotificationMessage.REFUND_REJECTED, now, 'N')
         );
         
         notifications.get(0).setIsRead('Y');

--- a/backend/src/test/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapperMockTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapperMockTest.java
@@ -1,0 +1,118 @@
+package com.metamong.mt.domain.reservation.repository.mybatis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.metamong.mt.domain.reservation.dto.request.ReservationRequestDto;
+import com.metamong.mt.domain.reservation.dto.response.HourlyUsageDto;
+import com.metamong.mt.domain.reservation.dto.response.ReservationResponseDto;
+import com.metamong.mt.domain.reservation.model.Reservation;
+import com.metamong.mt.domain.reservation.repository.jpa.ReservationRepository;
+import com.metamong.mt.testutil.DummyEntityGenerator;
+
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest
+@Slf4j
+public class ReservationMapperMockTest {
+
+    @Mock
+    ReservationMapper reservationMapper;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Test
+    @DisplayName("시설 이용자의 예약 목록 조회 - 성공")
+    void findReservationByConsId_success() {
+        // Given
+        Reservation reservation = DummyEntityGenerator.generateReservation(1L, 1L);
+
+        ReservationResponseDto dto = new ReservationResponseDto();
+        dto.setRvtId(reservation.getRvtId());
+        dto.setRvtDate(reservation.getRvtDate());
+        dto.setUsageStartTime(reservation.getUsageStartTime());
+        dto.setUsageEndTime(reservation.getUsageEndTime());
+        dto.setZoneName("Badminton Court");
+        dto.setFctName("Badminton Hall");
+
+        when(reservationMapper.findReservationByConsId(1L, 1, 10)).thenReturn(Arrays.asList(dto));
+
+        // When
+        List<ReservationResponseDto> result = reservationMapper.findReservationByConsId(1L, 1, 10);
+
+        // Then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getRvtId()).isEqualTo(1L);
+        assertThat(result.get(0).getRvtDate()).isEqualTo(LocalDate.of(2025, 2, 5));
+        assertThat(result.get(0).getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
+        assertThat(result.get(0).getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(result.get(0).getZoneName()).isEqualTo("Badminton Court");
+        assertThat(result.get(0).getFctName()).isEqualTo("Badminton Hall");
+    }
+
+    @Test
+    @DisplayName("예약 상세 조회 - 성공")
+    void findReservationByRvtId_success() {
+        // Given
+        Reservation reservation = DummyEntityGenerator.generateReservation(1L, 1L);
+
+        ReservationResponseDto dto = new ReservationResponseDto();
+        dto.setRvtId(reservation.getRvtId());
+        dto.setRvtDate(reservation.getRvtDate());
+        dto.setUsageStartTime(reservation.getUsageStartTime());
+        dto.setUsageEndTime(reservation.getUsageEndTime());
+        dto.setZoneName("Badminton Court");
+        dto.setFctName("Badminton Hall");
+
+        when(reservationMapper.findReservationByRvtId(1L)).thenReturn(dto);
+
+        // When
+        ReservationResponseDto result = reservationMapper.findReservationByRvtId(1L);
+
+        // Then
+        assertThat(result.getRvtId()).isEqualTo(1L);
+        assertThat(result.getRvtDate()).isEqualTo(LocalDate.of(2025, 2, 5));
+        assertThat(result.getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
+        assertThat(result.getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(result.getZoneName()).isEqualTo("Badminton Court");
+        assertThat(result.getFctName()).isEqualTo("Badminton Hall");
+    }
+
+    @Test
+    @DisplayName("현재 예약된 시간 조회 - 성공")
+    void getReservedTimes_success() {
+        // Given
+        ReservationRequestDto requestDto = new ReservationRequestDto(
+                1L, 1L, LocalDate.of(2025, 2, 10), LocalTime.of(6, 0), LocalTime.of(9, 0), 1);  
+        
+        HourlyUsageDto responseDto = new HourlyUsageDto();
+        responseDto.setTotalUsageCount(1);
+        responseDto.setUsageStartTime(LocalTime.of(6, 0));
+        responseDto.setUsageEndTime(LocalTime.of(9, 0));
+        
+        when(reservationMapper.getHourlyUsageCounts(requestDto))
+                .thenReturn(Arrays.asList(responseDto));
+        
+        // When
+        List<HourlyUsageDto> result = reservationMapper.getHourlyUsageCounts(requestDto);
+        
+        // Then
+        assertThat(result.get(0).getTotalUsageCount()).isEqualTo(1);
+        assertThat(result.get(0).getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
+        assertThat(result.get(0).getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
+    }
+
+}

--- a/backend/src/test/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapperTest.java
+++ b/backend/src/test/java/com/metamong/mt/domain/reservation/repository/mybatis/ReservationMapperTest.java
@@ -1,118 +1,165 @@
 package com.metamong.mt.domain.reservation.repository.mybatis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.any;
-import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.metamong.mt.domain.reservation.dto.request.ReservationRequestDto;
-import com.metamong.mt.domain.reservation.dto.response.HourlyUsageDto;
-import com.metamong.mt.domain.reservation.dto.response.ReservationResponseDto;
+import com.metamong.mt.domain.facility.model.Category;
+import com.metamong.mt.domain.facility.model.Facility;
+import com.metamong.mt.domain.facility.model.Zone;
+import com.metamong.mt.domain.member.model.FctProvider;
+import com.metamong.mt.domain.member.model.Member;
+import com.metamong.mt.domain.member.model.constant.Gender;
+import com.metamong.mt.domain.member.model.constant.Role;
+import com.metamong.mt.domain.reservation.dto.mapper.FindConsIdWithReservationTimeMapperDto;
 import com.metamong.mt.domain.reservation.model.Reservation;
-import com.metamong.mt.domain.reservation.repository.jpa.ReservationRepository;
-import com.metamong.mt.testutil.DummyEntityGenerator;
+import com.metamong.mt.global.constant.BooleanAlt;
 
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
+@Transactional
 @Slf4j
 public class ReservationMapperTest {
 
-    @Mock
-    ReservationMapper reservationMapper;
-
     @Autowired
-    ReservationRepository reservationRepository;
-
-    @Test
-    @DisplayName("시설 이용자의 예약 목록 조회 - 성공")
-    void findReservationByConsId_success() {
-        // Given
-        Reservation reservation = DummyEntityGenerator.generateReservation(1L, 1L);
-
-        ReservationResponseDto dto = new ReservationResponseDto();
-        dto.setRvtId(reservation.getRvtId());
-        dto.setRvtDate(reservation.getRvtDate());
-        dto.setUsageStartTime(reservation.getUsageStartTime());
-        dto.setUsageEndTime(reservation.getUsageEndTime());
-        dto.setZoneName("Badminton Court");
-        dto.setFctName("Badminton Hall");
-
-        when(reservationMapper.findReservationByConsId(1L, 1, 10)).thenReturn(Arrays.asList(dto));
-
+    ReservationMapper reservationMapper;
+    
+    @Autowired
+    EntityManager entityManager;
+    
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 })
+    @DisplayName("시작 시간이 현재 시각에서 {0} 시간 이내인 예약의 예약자 ID 가져오기")
+    void fetchConsIdWithReservationTimeIsLeftLessThanTheGivenTime(int testCase) {
+        Member prov = Member.builder()
+                .email("prov@gmail.com")
+                .memName("prov")
+                .password("1q2w3e4r")
+                .memPhone("010-1234-1234")
+                .gender(Gender.M)
+                .birthDate(LocalDate.of(1997, 9, 16))
+                .memPostalCode("12345")
+                .memAddress("addr")
+                .memDetailAddress("daddr")
+                .role(Role.ROLE_PROV)
+                .build();
+        
+        this.entityManager.persist(prov);
+        
+        FctProvider fctProvider = FctProvider.builder()
+                .provId(prov.getMemId())
+                .bizName("BIZ")
+                .bizRegNum("1234-123456")
+                .build();
+        
+        this.entityManager.persist(fctProvider);
+        
+        Category cat = new Category("600", "CAT");
+        this.entityManager.persist(cat);
+        cat = this.entityManager.find(Category.class, cat.getCatId());
+        
+        Facility facility = Facility.builder()
+                .cat(cat)
+                .provId(prov.getMemId())
+                .fctName("FCT")
+                .fctPostalCode("12345")
+                .fctAddress("ADDR")
+                .fctDetailAddress("DADDR")
+                .fctTel("02-1234-1234")
+                .fctGuide("GUIDE")
+                .openOnHolidays(BooleanAlt.Y)
+                .fctOpenTime(LocalTime.of(12, 0))
+                .fctCloseTime(LocalTime.of(18, 0))
+                .unitUsageTime(60)
+                .fctLatitude(37.152441)
+                .fctLongitude(128.134135)
+                .build();
+        
+        this.entityManager.persist(facility);
+        
+        Zone zone = Zone.builder()
+                .fctId(facility.getFctId())
+                .zoneName("ZONE")
+                .maxUserCount(1000)
+                .isSharedZone(BooleanAlt.Y)
+                .hourlyRate(5000)
+                .build();
+        
+        this.entityManager.persist(zone);
+        
+        LocalDateTime criteria = LocalDateTime.now();
+        List<Reservation> reservations = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            Member cons = Member.builder()
+                    .email("cons" + i + "@gmail.com")
+                    .memName("cons" + i)
+                    .password("1q2w3e4r")
+                    .memPhone("010-1234-12" + (i < 10 ? "0" + i : i))
+                    .gender(Gender.M)
+                    .birthDate(LocalDate.of(1997, 9, 16))
+                    .memPostalCode("123" + (i < 10 ? "0" + i : i))
+                    .memAddress("addr" + i)
+                    .memDetailAddress("daddr")
+                    .role(Role.ROLE_CONS)
+                    .build();
+            
+            this.entityManager.persist(cons);
+            
+            int num = i + 1;
+            LocalDateTime time = criteria.plusHours(num);
+            Reservation reservation = Reservation.builder()
+                    .consId(cons.getMemId())
+                    .zoneId(zone.getZoneId())
+                    .rvtDate(time.toLocalDate())
+                    .usageStartTime(LocalTime.of(time.getHour(), time.getMinute()))
+                    .usageEndTime(LocalTime.of(time.getHour(), time.getMinute()).plusHours(1))
+                    .usageCount(50)
+                    .build();
+            
+            this.entityManager.persist(reservation);
+            
+            reservations.add(reservation);
+        }
+        
+        this.entityManager.flush();
+        
         // When
-        List<ReservationResponseDto> result = reservationMapper.findReservationByConsId(1L, 1, 10);
-
-        // Then
-        assertThat(result).isNotEmpty();
-        assertThat(result.get(0).getRvtId()).isEqualTo(1L);
-        assertThat(result.get(0).getRvtDate()).isEqualTo(LocalDate.of(2025, 2, 5));
-        assertThat(result.get(0).getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
-        assertThat(result.get(0).getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
-        assertThat(result.get(0).getZoneName()).isEqualTo("Badminton Court");
-        assertThat(result.get(0).getFctName()).isEqualTo("Badminton Hall");
-    }
-
-    @Test
-    @DisplayName("예약 상세 조회 - 성공")
-    void findReservationByRvtId_success() {
-        // Given
-        Reservation reservation = DummyEntityGenerator.generateReservation(1L, 1L);
-
-        ReservationResponseDto dto = new ReservationResponseDto();
-        dto.setRvtId(reservation.getRvtId());
-        dto.setRvtDate(reservation.getRvtDate());
-        dto.setUsageStartTime(reservation.getUsageStartTime());
-        dto.setUsageEndTime(reservation.getUsageEndTime());
-        dto.setZoneName("Badminton Court");
-        dto.setFctName("Badminton Hall");
-
-        when(reservationMapper.findReservationByRvtId(1L)).thenReturn(dto);
-
-        // When
-        ReservationResponseDto result = reservationMapper.findReservationByRvtId(1L);
-
-        // Then
-        assertThat(result.getRvtId()).isEqualTo(1L);
-        assertThat(result.getRvtDate()).isEqualTo(LocalDate.of(2025, 2, 5));
-        assertThat(result.getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
-        assertThat(result.getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
-        assertThat(result.getZoneName()).isEqualTo("Badminton Court");
-        assertThat(result.getFctName()).isEqualTo("Badminton Hall");
-    }
-
-    @Test
-    @DisplayName("현재 예약된 시간 조회 - 성공")
-    void getReservedTimes_success() {
-        // Given
-        ReservationRequestDto requestDto = new ReservationRequestDto(
-                1L, 1L, LocalDate.of(2025, 2, 10), LocalTime.of(6, 0), LocalTime.of(9, 0), 1);  
-        
-        HourlyUsageDto responseDto = new HourlyUsageDto();
-        responseDto.setTotalUsageCount(1);
-        responseDto.setUsageStartTime(LocalTime.of(6, 0));
-        responseDto.setUsageEndTime(LocalTime.of(9, 0));
-        
-        when(reservationMapper.getHourlyUsageCounts(requestDto))
-                .thenReturn(Arrays.asList(responseDto));
-        
-        // When
-        List<HourlyUsageDto> result = reservationMapper.getHourlyUsageCounts(requestDto);
+        List<Long> result = this.reservationMapper.findConsIdWithLeftReservationTime(
+                new FindConsIdWithReservationTimeMapperDto(testCase, criteria)
+        );
         
         // Then
-        assertThat(result.get(0).getTotalUsageCount()).isEqualTo(1);
-        assertThat(result.get(0).getUsageStartTime()).isEqualTo(LocalTime.of(6, 0));
-        assertThat(result.get(0).getUsageEndTime()).isEqualTo(LocalTime.of(9, 0));
+        log.info("criteria={}", criteria);
+        LocalDateTime before = criteria.plusHours(testCase);
+        LocalDate beforeDate = before.toLocalDate();
+        LocalTime beforeTime = LocalTime.of(before.getHour(), before.getMinute());
+        log.info("beforeDate={}", beforeDate);
+        log.info("beforeTime={}", beforeTime);
+        log.info("rvtDate={}", reservations.stream().map(Reservation::getRvtDate).toList());
+        log.info("times={}", reservations.stream().map(Reservation::getUsageStartTime).toList());
+        log.info("consIds={}", reservations.stream().map(Reservation::getConsId).toList());
+        
+        Long[] filteredReservations = reservations.stream()
+                .filter((rvt) -> rvt.getRvtDate().isBefore(beforeDate)
+                        || (rvt.getRvtDate().equals(beforeDate) && (rvt.getUsageStartTime().isBefore(beforeTime) || rvt.getUsageStartTime().equals(beforeTime))))
+                .map(Reservation::getConsId)
+                .toArray(Long[]::new);
+        
+        log.info("filteredReservations={}", Arrays.toString(filteredReservations));
+        
+        assertThat(result).containsExactly(filteredReservations);
     }
-
 }

--- a/db-schema/schema.sql
+++ b/db-schema/schema.sql
@@ -215,7 +215,7 @@ CREATE TABLE payment (
     CONSTRAINT pk_payment PRIMARY KEY (rvt_id),
     CONSTRAINT fk_payment_rvt_id FOREIGN KEY (rvt_id)
         REFERENCES reservation (rvt_id),
-    CONSTRAINT payment_pay_state_domain CHECK (pay_state IN ('P', 'Q', 'R')),
+    CONSTRAINT payment_pay_state_domain CHECK (pay_state IN ('P', 'Q', 'R', 'N')),
     CONSTRAINT fk_payment_refund_bank_code FOREIGN KEY (refund_bank_code)
         REFERENCES bank (bank_code)
 );


### PR DESCRIPTION
# 설명
여러 위치에서 알림을 전송할 수 있도록 구현
- 예약 하루 전, 1시간 전 알림(이용자)
- 시설 등록 요청 수락/거절 알림
- 예약 시 알림(제공자)
- 환불 요청(관리자), 수락/거절(이용자)

이 중 "환불 수락/거절" 제외하고 모두 구현 완료

# 변경사항
- 각 행위에 따라 해당하는 알림을 전송하도록 구현
